### PR TITLE
core(backtest_asset) : implemented asset config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ build/
 .vs/
 
 # Data/logs
-data/
+data/book_updates/
+data/trades/
 *.log
 *.csv
 *.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(hftengine
   hftengine/main.cpp
   hftengine/core/orderbook/orderbook.cpp
   hftengine/utils/config/config_reader.cpp
+  hftengine/core/trading/backtest_asset.cpp
 )
 
 # THEN set properties

--- a/hftengine/core/trading/asset_config.h
+++ b/hftengine/core/trading/asset_config.h
@@ -1,0 +1,28 @@
+/*
+ * File: hftengine/hftengine/core/trading/asset_config.h
+ * Description: Struct that holds all per-asset simulation parameters including 
+ *              data paths, tick/lot sizes, latency model, fee structure, and fill behavior settings.
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-24
+ * License: Proprietary
+ */
+
+# pragma once
+
+# include <string>
+
+struct AssetConfig {
+    std::string l2update_file;
+    std::string trade_file;
+
+    double tick_size;
+    double lot_size;
+    double contract_multiplier;
+    bool is_inverse;
+
+    double maker_fee;
+    double taker_fee;
+
+    bool allow_partial_fills;
+    double power_queue_model_exponent;
+};

--- a/hftengine/core/trading/backtest_asset.h
+++ b/hftengine/core/trading/backtest_asset.h
@@ -1,0 +1,27 @@
+/*
+ * File: hftengine/hftengine/core/trading/backtest_asset.h
+ * Description: BacktestAsset encapsulates all per-instrument simulation parameters, data sources, and execution                 models used in the backtest engine.
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-26
+ * License: Proprietary
+ */
+
+# include <cstdint>
+# include <vector>
+
+# include "asset_config.h"
+# include "../types/usings.h"
+# include "../types/trade_side.h"
+
+class BacktestAsset {
+public:
+    explicit BacktestAsset(const AssetConfig& cfg)
+        : cfg_(cfg) {}
+
+    const AssetConfig& config() const {
+        return cfg_;
+    }
+
+private:
+    AssetConfig cfg_;
+};

--- a/hftengine/core/trading/backtest_engine.h
+++ b/hftengine/core/trading/backtest_engine.h
@@ -1,0 +1,21 @@
+/*
+ * File: hftengine/core/execution_engine/backtest_engine.h
+ * Description: Class structure for execution engine to take orders, fill orders.
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-26
+ * License: Proprietary
+ */
+
+# pragma once
+
+# include <vector>
+
+# include "../types/usings.h"
+# include "../trading/order.h"
+
+class BacktestEngine {
+public:
+	bool cancel_order();
+	bool submit_order();
+private:
+};

--- a/hftengine/core/trading/order.h
+++ b/hftengine/core/trading/order.h
@@ -1,0 +1,23 @@
+/*
+ * File: hft_bt_engine/core/trading/order.h
+ * Description: Defines the Order struct representing an order placed in the market.
+ *              Includes timestamp, book side (bid/ask), price, quantity, and associated order ID.
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-26
+ * License: Proprietary
+ */
+
+# pragma once
+
+# include "../types/usings.h"
+# include "../types/book_side.h"
+# include "../types/order_type.h"
+
+struct Order {
+    Timestamp timestamp_;
+    OrderId orderId_;
+    BookSide side_;
+    Price price_;
+    Quantity quantity_;
+    OrderType orderType_;
+};

--- a/hftengine/core/types/order_type.h
+++ b/hftengine/core/types/order_type.h
@@ -1,0 +1,16 @@
+/*
+ * File: hft_bt_engine/core/market_data/core/order_type.h
+ * Description: Enum class defining the different order types, .
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-26
+ * License: Proprietary
+ */
+
+#pragma once
+
+enum class OrderType
+{
+    LIMIT,
+    MARKET,
+    GTX
+};


### PR DESCRIPTION
Implemented a simple asset_config struct which has main properties of each asset:
- incremental book update file
- trades file
- tick size
- lot size
- contract multiplier
- maker fee
- taker fee
- partial fills or full_fills
- queue modeling parameter
BacktestAsset is a wrapper for the asset config. 