### PR TITLE
core(backtest_engine skeleton): header file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+BreakBeforeBraces: Attach
+AllowShortIfStatementsOnASingleLine: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ add_executable(hftengine
   hftengine/main.cpp
   hftengine/core/orderbook/orderbook.cpp
   hftengine/utils/config/config_reader.cpp
-  hftengine/core/trading/backtest_asset.cpp
 )
 
 # THEN set properties

--- a/hftengine/core/trading/backtest_asset.h
+++ b/hftengine/core/trading/backtest_asset.h
@@ -1,27 +1,25 @@
 /*
  * File: hftengine/hftengine/core/trading/backtest_asset.h
- * Description: BacktestAsset encapsulates all per-instrument simulation parameters, data sources, and execution                 models used in the backtest engine.
- * Author: Arvind Rathnashyam
+ * Description: BacktestAsset encapsulates all per-instrument simulation
+ * parameters, data sources, and execution                 models used in the
+ * backtest engine. Author: Arvind Rathnashyam Date: 2025-06-26 License:
  * Date: 2025-06-26
- * License: Proprietary
+ * License: Proprietary 
  */
 
-# include <cstdint>
-# include <vector>
+#include <cstdint>
+#include <vector>
 
-# include "asset_config.h"
-# include "../types/usings.h"
-# include "../types/trade_side.h"
+#include "../types/trade_side.h"
+#include "../types/usings.h"
+#include "asset_config.h"
 
 class BacktestAsset {
 public:
-    explicit BacktestAsset(const AssetConfig& cfg)
-        : cfg_(cfg) {}
+  explicit BacktestAsset(const AssetConfig &cfg) : cfg_(cfg) {}
 
-    const AssetConfig& config() const {
-        return cfg_;
-    }
+  const AssetConfig &config() const { return cfg_; }
 
 private:
-    AssetConfig cfg_;
+  AssetConfig cfg_;
 };

--- a/hftengine/core/trading/backtest_engine.cpp
+++ b/hftengine/core/trading/backtest_engine.cpp
@@ -1,0 +1,8 @@
+/*
+ * File: hftengine/core/execution_engine/backtest_engine.h
+ * Description: Class structure for execution engine to take orders, fill
+	            orders. 
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-26
+ * License: Proprietary
+ */

--- a/hftengine/core/trading/backtest_engine.h
+++ b/hftengine/core/trading/backtest_engine.h
@@ -1,21 +1,42 @@
 /*
  * File: hftengine/core/execution_engine/backtest_engine.h
- * Description: Class structure for execution engine to take orders, fill orders.
- * Author: Arvind Rathnashyam
+ * Description: Class structure for execution engine to take orders, fill
+ * orders. Author: Arvind Rathnashyam
  * Date: 2025-06-26
  * License: Proprietary
  */
 
-# pragma once
+#pragma once
 
-# include <vector>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
 
-# include "../types/usings.h"
-# include "../trading/order.h"
+#include "../orderbook/orderbook.h"
+#include "../trading/order.h"
+#include "../types/order_type.h"
+#include "../types/time_in_force.h"
+#include "../types/usings.h"
+#include "backtest_asset.h"
 
 class BacktestEngine {
-public:
-	bool cancel_order();
-	bool submit_order();
-private:
+  public:
+    bool elapse(std::uint64_t microseconds);
+
+    bool submit_buy_order(int asset_id, OrderId orderId, Price price,
+                          Quantity quantity, TimeInForce tif,
+                          OrderType orderType);
+
+    bool submit_sell_order(int asset_id, OrderId orderId, Price price,
+                           Quantity quantity, TimeInForce tif,
+                           OrderType orderType);
+
+    void cancel(int asset_id, OrderId orderID);
+
+  private:
+    BacktestAsset asset_;
+    Timestamp current_time_us_;
+
+    OrderBook orderbook_;
+    std::unordered_map<OrderId, Order> orders_;
 };

--- a/hftengine/core/types/order_type.h
+++ b/hftengine/core/types/order_type.h
@@ -11,6 +11,5 @@
 enum class OrderType
 {
     LIMIT,
-    MARKET,
-    GTX
+    MARKET
 };

--- a/hftengine/core/types/time_in_force.h
+++ b/hftengine/core/types/time_in_force.h
@@ -1,0 +1,17 @@
+/*
+ * File: hft_bt_engine/core/market_data/core/time_in_force.h
+ * Description: Enum class defining the different time in force types, GTC, GTX, FOK, IOC.
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-27
+ * License: Proprietary
+ */
+
+#pragma once
+
+enum class TimeInForce
+{
+    GTC, // good till cancel
+    GTX, // good till crossing
+    FOK, // fill or cancel
+    IOC  // immediate or cancel
+};


### PR DESCRIPTION
Implemented the backtest_engine header file, sets up logic for : 
- elapse
- buy/sell orders
- time in force
- order types
- unordered map for order tracking