### PR TITLE
core(execution_engine/order_matching) - implemented order matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(hftengine PRIVATE
 # Compiler flags (AFTER target is defined)
 target_compile_options(hftengine PRIVATE
   $<$<CONFIG:Release>:-O3>
-  $<$<CONFIG:Debug>:-O3 -g -Wall -Wextra>
+  $<$<CONFIG:Debug>:-O3 -Wall -Wextra -Wpedantic>
 )
 
 # Catch2 test setup
@@ -57,14 +57,14 @@ target_include_directories(test_config_reader PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/hftengine
 )
 
-# 3. L2StreamReader Tests
-add_executable(test_l2_stream_reader
-  tests/test_l2_stream_reader.cpp
-  hftengine/core/data/readers/l2_stream_reader.cpp
+# 3. BookStreamReader Tests
+add_executable(test_book_stream_reader
+  tests/test_book_stream_reader.cpp
+  hftengine/core/data/readers/book_stream_reader.cpp
   hftengine/core/orderbook/orderbook.cpp
 )
 
-target_include_directories(test_l2_stream_reader PRIVATE
+target_include_directories(test_book_stream_reader PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/hftengine
 )
 
@@ -84,34 +84,48 @@ add_executable(test_market_data_feed
   tests/test_market_data_feed.cpp
   hftengine/core/data/readers/market_data_feed.cpp
   hftengine/core/data/readers/trade_stream_reader.cpp
-  hftengine/core/data/readers/l2_stream_reader.cpp
+  hftengine/core/data/readers/book_stream_reader.cpp
 )
 
 target_include_directories(test_market_data_feed PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/hftengine
 )
 
+# 6. Execution Engine Tests
+add_executable(test_execution_engine
+  tests/test_execution_engine.cpp
+  hftengine/core/execution_engine/execution_engine.cpp
+  hftengine/core/orderbook/orderbook.cpp
+)
+
+target_include_directories(test_execution_engine PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/hftengine
+)
+
 # Link  test executables to Catch2
 target_link_libraries(test_orderbook PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(test_config_reader PRIVATE Catch2::Catch2WithMain)
-target_link_libraries(test_l2_stream_reader PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(test_book_stream_reader PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(test_trade_stream_reader PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(test_market_data_feed PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(test_execution_engine PRIVATE Catch2::Catch2WithMain)
 
 # Discover tests for both executables
 include(CTest)
 include(Catch)
 catch_discover_tests(test_orderbook)
 catch_discover_tests(test_config_reader)
-catch_discover_tests(test_l2_stream_reader)
+catch_discover_tests(test_book_stream_reader)
 catch_discover_tests(test_trade_stream_reader)
 catch_discover_tests(test_market_data_feed)
+catch_discover_tests(test_execution_engine)
 
 # Optional: Add a global test target
 add_custom_target(run_all_tests DEPENDS
   test_orderbook
   test_config_reader
-  test_l2_stream_reader
+  test_book_stream_reader
   test_trade_stream_reader
   test_market_data_feed
+  test_execution_engine
 )

--- a/README.md
+++ b/README.md
@@ -1,14 +1,49 @@
 # hftengine
 
-## High-Frequency Level 2 Trading Backtesting 
+## High-Frequency Level 2 Trading Backtesting Engine
 
-This framework is designed for developing and backtesting high frequency market making strategies in crypto markets. The replay accounts for feed and order latencies, as well as simulating queue position for order fills. The engine takes as input trade and level 2 update data.
+`hftengine` is a high-performance C++ framework for backtesting high-frequency trading (HFT) strategies on **Level 2 crypto market data**. It supports **full order book reconstruction**, **queue position tracking**, and **realistic order matching** with configurable latency models.
+
+This engine is designed for research and development of market-making and latency-sensitive strategies on tick-level data.
+
+---
 
 ## Key Features
 
-- C++ implementation.
-- Full order book reconstruction based on level two market-by-price feeds. 
+- **C++20 implementation** for speed and low-level control.
+- **Full depth-of-book simulation** from market-by-price Level 2 feeds.
+- **Feed and order latency simulation** for realistic execution timing.
+- **Queue position estimation** for passive order fills.
+- **Modular testable architecture** with Catch2 unit tests.
+
+---
+
+## Quick Start
 
 ### Prerequisites
-- C++20 compiler
-- CMake 3.12+
+
+- C++20-compatible compiler (GCC >= 10, Clang >= 11, MSVC >= 19.28)
+- [CMake](https://cmake.org/) version 3.12 or later
+
+### Build Instructions
+
+```bash
+# Clone the repository
+git clone https://github.com/your_username/hftengine.git
+cd hftengine
+
+# Create and enter build directory
+mkdir build
+cd build
+
+# Configure the build
+cmake ..
+
+# Compile the engine (Debug build)
+cmake --build . --config Debug
+
+# Run tests inside the build directory
+ctest
+
+# Run the engine inside the build directory
+./hftengine

--- a/hftengine/core/data/readers/book_stream_reader.cpp
+++ b/hftengine/core/data/readers/book_stream_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * File: hft_bt_engine/core/data/readers/L2_stream_reader.cpp
+ * File: hft_bt_engine/core/data/readers/book_stream_reader.cpp
  * Description: Class for parsing and reading csv files with tardis incremental l2 book data.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-24
@@ -13,14 +13,14 @@
 # include <cmath>
 # include <cstdint>
 
-# include "l2_stream_reader.hpp"
-# include "../../market_data/l2_update.h"
+# include "book_stream_reader.hpp"
+# include "../../market_data/book_update.h"
 # include "../../types/usings.h"
 # include "../../types/book_side.h"
 # include "../../../../external/csv/csv.h"
 
- // l2_stream_reader.cpp
-struct L2StreamReader::CSVReaderImpl {
+ // book_stream_reader.cpp
+struct BookStreamReader::CSVReaderImpl {
     io::CSVReader<5> reader;
     std::unordered_map<std::string, size_t> column_map;
 
@@ -28,16 +28,16 @@ struct L2StreamReader::CSVReaderImpl {
         : reader(filename) {}  // Initialize CSVReader here
 };
 
-L2StreamReader::~L2StreamReader() = default;
+BookStreamReader::~BookStreamReader() = default;
 
-L2StreamReader::L2StreamReader(double tick_size, double lot_size)
+BookStreamReader::BookStreamReader(double tick_size, double lot_size)
     : tick_size_(tick_size), lot_size_(lot_size)
 {
     if (tick_size <= 0.0) throw std::invalid_argument("Tick size must be positive");
     if (lot_size <= 0.0) throw std::invalid_argument("Lot size must be positive");
 }
 
-void L2StreamReader::open(const std::string& filename) {
+void BookStreamReader::open(const std::string& filename) {
     csv_reader_ = std::make_unique<CSVReaderImpl>(filename);  // Now works
 
     // Column header processing
@@ -54,7 +54,7 @@ void L2StreamReader::open(const std::string& filename) {
         }
     }
 }
-bool L2StreamReader::parse_next(L2Update& update) {
+bool BookStreamReader::parse_next(BookUpdate& update) {
     if (!csv_reader_) {
         return false;
     }
@@ -99,10 +99,10 @@ bool L2StreamReader::parse_next(L2Update& update) {
     return false;
 }
 
-PriceTick L2StreamReader::to_tick(double price) const {
+PriceTick BookStreamReader::to_tick(double price) const {
     return static_cast<PriceTick>(std::round(price / tick_size_));
 }
 
-QuantityLot L2StreamReader::to_lots(double qty) const {
+QuantityLot BookStreamReader::to_lots(double qty) const {
     return static_cast<QuantityLot>(std::round(qty / lot_size_));
 }

--- a/hftengine/core/data/readers/book_stream_reader.hpp
+++ b/hftengine/core/data/readers/book_stream_reader.hpp
@@ -1,5 +1,5 @@
 /*
- * File: hftengine/core/data/readers/l2_stream_reader.h
+ * File: hftengine/core/data/readers/book_stream_reader.h
  * Description: Class to read L2 data from tardis incremental_book_update csv files.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-24
@@ -13,20 +13,20 @@
 # include <unordered_map>
 # include <memory>
 
-# include "../../market_data/l2_update.h"
+# include "../../market_data/book_update.h"
 # include "../../types/usings.h"
 # include "../../types/book_side.h"
 
-class L2StreamReader {
+class BookStreamReader {
 public:
-    explicit L2StreamReader(double tick_size, double lot_size);
-    ~L2StreamReader();
+    explicit BookStreamReader(double tick_size, double lot_size);
+    ~BookStreamReader();
 
     // Open CSV file and prepare for reading
     void open(const std::string& filename);
 
     // Parse next line (returns false on EOF)
-    bool parse_next(L2Update& update);
+    bool parse_next(BookUpdate& update);
 
     // Conversion utilities
     PriceTick to_tick(double price) const;

--- a/hftengine/core/data/readers/market_data_feed.cpp
+++ b/hftengine/core/data/readers/market_data_feed.cpp
@@ -1,6 +1,6 @@
 /*
  * File: hftengine/core/data/readers/market_data_feed.cpp
- * Description: Class to stream trade and l2 data chronologically.
+ * Description: Class to stream trade and book_update data chronologically.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-26
  * License: Proprietary
@@ -13,32 +13,32 @@
 
 # include "market_data_feed.hpp"
 # include "../../market_data/trade.h"
-# include "../../market_data/l2_update.h"
+# include "../../market_data/book_update.h"
 # include "../../types/usings.h"
 # include "../../orderbook/orderbook.h"
 # include "../../types/event_type.h"
-# include "l2_stream_reader.hpp"
+# include "book_stream_reader.hpp"
 # include "trade_stream_reader.hpp"
 
 
-MarketDataFeed::MarketDataFeed(L2StreamReader& l2_stream, TradeStreamReader& trade_stream)
-    : l2_stream_(l2_stream), trade_stream_(trade_stream) {}
+MarketDataFeed::MarketDataFeed(BookStreamReader& book_stream, TradeStreamReader& trade_stream)
+    : book_stream_(book_stream), trade_stream_(trade_stream) {}
 
-bool MarketDataFeed::next_event(EventType& event_type, L2Update& l2_update, Trade& trade) {
+bool MarketDataFeed::next_event(EventType& event_type, BookUpdate& book_update, Trade& trade) {
     if (last_event_ == EventType::Trade) {
         trade_ok = trade_stream_.parse_next(trade);
     }
-    else if (last_event_ == EventType::L2Update) {
-        l2_ok = l2_stream_.parse_next(l2_update);
+    else if (last_event_ == EventType::BookUpdate) {
+        book_ok = book_stream_.parse_next(book_update);
     }
     else {
         trade_ok = trade_stream_.parse_next(trade);
-        l2_ok = l2_stream_.parse_next(l2_update);
+        book_ok = book_stream_.parse_next(book_update);
     }
-    if (trade_ok && l2_ok) {
-        (trade.timestamp_ < l2_update.timestamp_)
+    if (trade_ok && book_ok) {
+        (trade.timestamp_ < book_update.timestamp_)
             ? event_type = EventType::Trade
-            : event_type = EventType::L2Update;
+            : event_type = EventType::BookUpdate;
         last_event_ = event_type;
         return true;
     }
@@ -47,8 +47,8 @@ bool MarketDataFeed::next_event(EventType& event_type, L2Update& l2_update, Trad
         last_event_ = event_type;
         return true;
     }
-    else if (l2_ok) {
-        event_type = EventType::L2Update;
+    else if (book_ok) {
+        event_type = EventType::BookUpdate;
         last_event_ = event_type;
         return true;
     }

--- a/hftengine/core/data/readers/market_data_feed.hpp
+++ b/hftengine/core/data/readers/market_data_feed.hpp
@@ -1,6 +1,6 @@
 /*
  * File: hftengine/core/data/readers/market_data_feed.h
- * Description: Class to stream trade and l2 data chronologically.
+ * Description: Class to stream trade and book_update data chronologically.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-25
  * License: Proprietary
@@ -14,25 +14,25 @@
 # include <memory>
 
 # include "../../market_data/trade.h"
-# include "../../market_data/l2_update.h"
+# include "../../market_data/book_update.h"
 # include "../../types/usings.h"
 # include "../../orderbook/orderbook.h"
 # include "../../types/event_type.h"
-# include "l2_stream_reader.hpp"
+# include "book_stream_reader.hpp"
 # include "trade_stream_reader.hpp"
 
 
 class MarketDataFeed {
 public:
-    MarketDataFeed(L2StreamReader& l2_stream, TradeStreamReader& trade_stream);
-	bool next_event(EventType& event_type, L2Update& l2_update, Trade& trade);
+    MarketDataFeed(BookStreamReader& book_stream, TradeStreamReader& trade_stream);
+	bool next_event(EventType& event_type, BookUpdate& book_update, Trade& trade);
 
 private:
-	L2StreamReader& l2_stream_;
+	BookStreamReader& book_stream_;
 	TradeStreamReader& trade_stream_;
 
 	bool trade_ok;
-	bool l2_ok;
+	bool book_ok;
 
 	EventType last_event_;
 };

--- a/hftengine/core/execution_engine/execution_engine.cpp
+++ b/hftengine/core/execution_engine/execution_engine.cpp
@@ -7,34 +7,419 @@
  * License: Proprietary
  */
 
+#include <cmath>
+#include <iostream>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
+#include "../trading/fill.h"
 #include "../types/book_side.h"
 #include "../types/order_type.h"
+#include "../types/time_in_force.h"
 #include "../types/usings.h"
 #include "execution_engine.h"
 
 ExecutionEngine::ExecutionEngine() {}
 
-bool submit_buy_order(int asset_id, const Timestamp &timestamp,
-                      const OrderId &orderId, const Price &price,
-                      const Quantity &quantity, const TimeInForce &tif,
-                      const OrderType &orderType) {
-    if (quantity <= 0.0 || price <= 0.0) return false;
-    Order order = {timestamp, orderId, BookSide::Bid, price,
-                   quantity,  tif,     orderType};
-    bid_orders_[orderId] = order;
+/**
+ * @brief Executes a market order against the order book.
+ *
+ * This function attempts to fill a market buy or sell order by consuming
+ * liquidity from the opposing side of the order book (i.e., sell orders consume
+ * bids, and buy orders consume asks). It traverses the price levels from best
+ * price onward, filling as much of the order as available at each level.
+ *
+ * At each level, the function compares the available depth with the remaining
+ * unfilled quantity of the order. If sufficient liquidity is available, it
+ * performs a full fill for the remaining quantity. Otherwise, it partially
+ * fills and proceeds to the next price level.
+ *
+ * All generated fills are recorded in the internal `fills_` vector, and the
+ * order’s `filled_quantity_` is updated accordingly. The order is passed as a
+ * shared pointer to maintain shared state across components (e.g., strategy,
+ * book, execution engine).
+ *
+ * @param asset_id Identifier of the asset being traded.
+ * @param side Direction of the trade (TradeSide::Buy or TradeSide::Sell).
+ * @param order Shared pointer to the market order to be executed.
+ *              The order's fill state will be updated in-place.
+ */
+void ExecutionEngine::execute_market_order(int asset_id, TradeSide side,
+                                           std::shared_ptr<Order> order) {
+    int level = 0;
+    int levels = (side == TradeSide::Buy) ? orderbook_.ask_levels()
+                                          : orderbook_.bid_levels();
+    while (order->filled_quantity_ < order->quantity_ && level < levels) {
+        Quantity level_depth =
+            (side == TradeSide::Buy)
+                ? orderbook_.depth_at_level(BookSide::Ask, level)
+                : orderbook_.depth_at_level(BookSide::Bid, level);
+        Price level_price =
+            (side == TradeSide::Buy)
+                ? orderbook_.price_at_level(BookSide::Ask, level)
+                : orderbook_.price_at_level(BookSide::Bid, level);
+        if (level_depth > (order->quantity_ - order->filled_quantity_)) {
+            Fill fill = {.asset_id_ = asset_id,
+                         .timestamp_ = order->timestamp_,
+                         .orderId_ = order->orderId_,
+                         .side_ = side,
+                         .price_ = level_price,
+                         .quantity_ =
+                             order->quantity_ - order->filled_quantity_,
+                         .is_maker = false};
+            order->filled_quantity_ = order->quantity_;
+            fills_.emplace_back(fill);
+        } else {
+            Fill fill = {.asset_id_ = asset_id,
+                         .timestamp_ = order->timestamp_,
+                         .orderId_ = order->orderId_,
+                         .side_ = side,
+                         .price_ = level_price,
+                         .quantity_ = level_depth,
+                         .is_maker = false};
+            order->filled_quantity_ += level_depth;
+            fills_.emplace_back(fill);
+        }
+        level++;
+    }
+}
+
+/**
+ * @brief Executes a Limit Fill-Or-Kill (FOK) order against the order book.
+ *
+ * A Fill-Or-Kill (FOK) order must be fully executed immediately at the
+ * specified limit price or better. If insufficient liquidity is available at
+ * acceptable price levels at the time of submission, the order is rejected and
+ * no fills occur.
+ *
+ * This function first scans the relevant side of the order book (asks for buys,
+ * bids for sells) to determine whether enough volume is available at prices
+ * equal to or better than the order's limit price.
+ *
+ * If sufficient liquidity exists, the order is executed in full using
+ * aggressive taker fills at the available price levels. If not, the function
+ * exits early without modifying the order or generating any fills.
+ *
+ * All successful fills are appended to the internal `fills_` vector, and the
+ * order's `filled_quantity_` is updated in-place. No partial fills are allowed.
+ *
+ * @param asset_id Identifier of the asset being traded.
+ * @param side Trade direction: TradeSide::Buy or TradeSide::Sell.
+ * @param order Shared pointer to the FOK order to be executed.
+ *              The order's `filled_quantity_` will be updated if filled.
+ * @return true if the order was fully filled; false if rejected with no fills.
+ */
+bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
+                                        std::shared_ptr<Order> order) {
+    int level = -1;
+    int levels = (side == TradeSide::Buy) ? orderbook_.ask_levels()
+                                          : orderbook_.bid_levels();
+    Quantity available_qty;
+    while (++level < levels && available_qty < order->quantity_) {
+        Price level_price =
+            (side == TradeSide::Buy)
+                ? orderbook_.price_at_level(BookSide::Ask, level)
+                : orderbook_.price_at_level(BookSide::Bid, level);
+        if (side == TradeSide::Buy && level_price > order->price_) break;
+        if (side == TradeSide::Sell && level_price < order->price_) break;
+        available_qty += (side == TradeSide::Buy)
+                             ? orderbook_.depth_at_level(BookSide::Ask, level)
+                             : orderbook_.depth_at_level(BookSide::Bid, level);
+    }
+    if (available_qty < order->quantity_) return false;
+    level = -1;
+    while (++level < levels && order->filled_quantity_ < order->quantity_) {
+        Quantity level_depth =
+            (side == TradeSide::Buy)
+                ? orderbook_.depth_at_level(BookSide::Ask, level)
+                : orderbook_.depth_at_level(BookSide::Bid, level);
+        Price level_price =
+            (side == TradeSide::Buy)
+                ? orderbook_.price_at_level(BookSide::Ask, level)
+                : orderbook_.price_at_level(BookSide::Bid, level);
+        if (side == TradeSide::Buy && level_price > order->price_) break;
+        if (side == TradeSide::Sell && level_price < order->price_) break;
+        if (level_depth > (order->quantity_ - order->filled_quantity_)) {
+            Fill fill = {.asset_id_ = asset_id,
+                         .timestamp_ = order->timestamp_,
+                         .orderId_ = order->orderId_,
+                         .side_ = TradeSide::Buy,
+                         .price_ = level_price,
+                         .quantity_ =
+                             order->quantity_ - order->filled_quantity_,
+                         .is_maker = false};
+            order->filled_quantity_ = order->quantity_;
+            fills_.emplace_back(fill);
+        } else {
+            Fill fill = {.asset_id_ = asset_id,
+                         .timestamp_ = order->timestamp_,
+                         .orderId_ = order->orderId_,
+                         .side_ = TradeSide::Buy,
+                         .price_ = level_price,
+                         .quantity_ = level_depth,
+                         .is_maker = false};
+            order->filled_quantity_ += level_depth;
+            fills_.emplace_back(fill);
+        }
+    }
     return true;
 }
 
-bool submit_sell_order(int asset_id, const Timestamp &timestamp,
-                       const OrderId &orderId, const Price &price,
-                       const Quantity &quantity, const TimeInForce &tif,
-                       const OrderType &orderType) {
-    if (quantity <= 0.0 || price <= 0.0) return false;
-    Order order = {timestamp, orderId, BookSide::Ask, price,
-                   quantity,  tif,     orderType};
-    ask_orders_[orderId] = order;
+/**
+ * @brief Executes a Limit Immediate-Or-Cancel (IOC) order against the order
+ * book.
+ *
+ * An Immediate-Or-Cancel (IOC) order attempts to fill as much of the specified
+ * quantity as possible immediately, at prices equal to or better than the given
+ * limit price. Any remaining unfilled portion is automatically canceled — the
+ * order does not rest on the book.
+ *
+ * This function scans the order book starting from the best opposing price
+ * level (asks for buy orders, bids for sell orders), and aggregates as many
+ * fills as possible without exceeding the order’s limit price or remaining
+ * quantity.
+ *
+ * Fills are recorded in the internal `fills_` vector, and the order’s
+ * `filled_quantity_` is updated in-place. The order object is passed as a
+ * shared pointer so that state is shared across engine components.
+ *
+ * @param asset_id Identifier of the asset being traded.
+ * @param side Direction of the trade: TradeSide::Buy or TradeSide::Sell.
+ * @param order Shared pointer to the IOC order being executed.
+ *              The `filled_quantity_` field will be updated accordingly.
+ * @return true if the order was partially or fully filled; false if no fills
+ * occurred.
+ */
+bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
+                                        std::shared_ptr<Order> order) {
+    int level = 0;
+    int levels = (side == TradeSide::Buy) ? orderbook_.ask_levels()
+                                          : orderbook_.bid_levels();
+    while (level < levels && order->filled_quantity_ < order->quantity_) {
+        Price level_price =
+            (side == TradeSide::Buy)
+                ? orderbook_.price_at_level(BookSide::Ask, level)
+                : orderbook_.price_at_level(BookSide::Bid, level);
+        if (side == TradeSide::Buy && level_price > order->price_) break;
+        if (side == TradeSide::Sell && level_price < order->price_) break;
+        Quantity level_depth =
+            (side == TradeSide::Buy)
+                ? orderbook_.depth_at_level(BookSide::Ask, level)
+                : orderbook_.depth_at_level(BookSide::Bid, level);
+        if (level_depth > (order->quantity_ - order->filled_quantity_)) {
+            Fill fill = {.asset_id_ = asset_id,
+                         .timestamp_ = order->timestamp_,
+                         .orderId_ = order->orderId_,
+                         .side_ = side,
+                         .price_ = level_price,
+                         .quantity_ =
+                             order->quantity_ - order->filled_quantity_,
+                         .is_maker = false};
+            order->filled_quantity_ = order->quantity_;
+            fills_.emplace_back(fill);
+        } else {
+            Fill fill = {.asset_id_ = asset_id,
+                         .timestamp_ = order->timestamp_,
+                         .orderId_ = order->orderId_,
+                         .side_ = side,
+                         .price_ = level_price,
+                         .quantity_ = level_depth,
+                         .is_maker = false};
+            order->filled_quantity_ += level_depth;
+            fills_.emplace_back(fill);
+        }
+        level++;
+    }
+    return (order->filled_quantity_ > 0) ? true : false;
+}
+
+/**
+ * @brief Places a Limit GTX (Post-Only) order without taking liquidity.
+ *
+ * A GTX (Good-Till-Cancel Post-Only) order is rejected if it would cross the
+ * spread and match with any existing resting orders. This ensures the order
+ * only adds liquidity to the order book and does not take liquidity.
+ *
+ * The function first checks whether the given order would cross the opposing
+ * side of the book. If so, it is rejected (i.e., not inserted into the book).
+ * Otherwise, the order is inserted at its price level and its estimated queue
+ * position is recorded based on the current depth at that price.
+ *
+ * Both bid-side and ask-side GTX orders are supported. For example:
+ * - A buy GTX order is rejected if its price is >= best ask.
+ * - A sell GTX order is rejected if its price is <= best bid.
+ *
+ * All accepted orders are stored in the appropriate side's price map and
+ * tracked in the global `orders_` map.
+ *
+ * @param asset_id Identifier of the traded asset.
+ * @param order Shared pointer to the order to be placed. `queueEst_` will be
+ * initialized.
+ * @return true if the order was accepted and added to the book; false if it
+ * would take liquidity.
+ *
+ * @note This function does not attempt to match or execute the order.
+ *       It only handles enforcement and insertion of passive orders.
+ */
+bool ExecutionEngine::place_gtx_order(int asset_id,
+                                      std::shared_ptr<Order> order) {
+    Price best_ask = orderbook_.best_ask();
+    Price best_bid = orderbook_.best_bid();
+    if ((order->side_ == BookSide::Bid &&
+         best_ask > 0.0 &&
+         order->price_ >= best_ask) ||
+        (order->side_ == BookSide::Ask && best_bid > 0.0 && 
+         order->price_ <= best_bid))
+        return false;
+
+    order->queueEst_ = orderbook_.depth_at(order->side_, order->price_);
+    if (order->side_ == BookSide::Bid)
+        bid_orders_[order->price_] = order;
+    else
+        ask_orders_[order->price_] = order;
+    orders_[order->orderId_] = order;
     return true;
 }
+
+/*
+ * @brief Handles a book update and updates internal queue position estimates.
+ *
+ * This function processes a BookUpdate for a given asset by:
+ * - Retrieving the current quantity at the updated price level.
+ * - Computing the quantity change (delta).
+ * - If it's a bid-side reduction and our order exists at that price,
+ *   updating our queue position estimate based on a probabilistic fill model.
+ * - Applying the update to the order book.
+ *
+ * The fill probability is estimated using the formula:
+ * \f[
+ * p_n = \frac{f(V_n)}{f(V_n) + f(\max(Q_n - S - V_n, 0))}
+ * \f]
+ * where:
+ * - \(V_n\) is our previous queue estimate,
+ * - \(S\) is the remaining quantity in our order,
+ * - \(Q_n\) is the total depth at that price before the update,
+ * - \(\delta Q_n\) is the change in depth,
+ * - and \(f(x) = \log(1 + x)\).
+ *
+ * @param asset_id The ID of the asset this update pertains to.
+ * @param book_update The update event (side, price, new quantity).
+ */
+void ExecutionEngine::handle_book_update(int asset_id,
+                                         const BookUpdate &book_update) {
+    // update queue position estimations
+    Quantity Q_n = orderbook_.depth_at(book_update.side_, book_update.price_);
+    Quantity deltaQ_n = book_update.quantity_ - Q_n;
+    if (deltaQ_n < 0) {
+        if (book_update.side_ == BookSide::Bid) {
+            auto it = bid_orders_.find(book_update.price_);
+            if (it != bid_orders_.end()) {
+                Quantity S =
+                    it->second->quantity_ - it->second->filled_quantity_;
+                Quantity V_n = it->second->queueEst_;
+                double p_n =
+                    (f(V_n) > 0.0)
+                        ? (f(V_n) / (f(V_n) + f(std::max(Q_n - S - V_n, 0.0))))
+                        : 0.0;
+                Quantity V_nplus1 = std::max(V_n + p_n * deltaQ_n, 0.0);
+                it->second->queueEst_ = V_nplus1;
+            }
+        } else if (book_update.side_ == BookSide::Ask) {
+            auto it = ask_orders_.find(book_update.price_);
+            if (it != ask_orders_.end()) {
+                Quantity S =
+                    it->second->quantity_ - it->second->filled_quantity_;
+                Quantity V_n = it->second->queueEst_;
+                double p_n =
+                    (f(V_n) > 0.0)
+                        ? (f(V_n) / (f(V_n) + f(std::max(Q_n - S - V_n, 0.0))))
+                        : 0.0;
+                Quantity V_nplus1 = std::max(V_n + p_n * deltaQ_n, 0.0);
+                it->second->queueEst_ = V_nplus1;
+            }
+        }
+    }
+    // update orderbook
+    orderbook_.apply_book_update(book_update);
+}
+
+/**
+ * @brief Processes an incoming trade and fills a matching resting order if
+ * eligible.
+ *
+ * This function simulates passive order fills by checking if there is a resting
+ * order at the trade price on the opposite side of the trade. If a matching
+ * order exists at the same price, has queue position zero (i.e., is at the
+ * front), and was placed before the trade timestamp, it will be filled.
+ *
+ * Specifically:
+ * - For a Sell trade: attempts to fill the top Buy order at the trade price.
+ * - For a Buy trade: attempts to fill the top Sell order at the trade price.
+ * - A fill is only allowed if the resting order has `queueEst_ == 0.0`, meaning
+ *   it is first in line to be filled.
+ * - The filled quantity is the minimum of the trade quantity and the unfilled
+ *   portion of the resting order.
+ *
+ * If all conditions are met, a fill is created and stored in the internal
+ * `fills_` list.
+ *
+ * @param asset_id Identifier for the asset being traded.
+ * @param trade Incoming trade information (price, quantity, side, timestamp,
+ * etc.).
+ */
+void ExecutionEngine::handle_trade(int asset_id, const Trade &trade) {
+    auto it = (trade.side_ == TradeSide::Sell) ? bid_orders_.find(trade.price_)
+                                              : ask_orders_.find(trade.price_);
+    auto end =
+        (trade.side_ == TradeSide::Sell) ? bid_orders_.end() : ask_orders_.end();
+    std::cout << "looking for order\n";
+    if (it == end) return;
+    std::cout << "order found\n";
+    auto order = it->second;
+    if (order->timestamp_ >= trade.timestamp_) return;
+
+    if (order->queueEst_ == 0.0 && order->filled_quantity_ < order->quantity_) {
+        Quantity fill_qty = std::min(
+            trade.quantity_, order->quantity_ - order->filled_quantity_);
+        order->filled_quantity_ += fill_qty;
+        fills_.emplace_back(Fill{.asset_id_ = asset_id,
+                                 .timestamp_ = trade.timestamp_,
+                                 .orderId_ = order->orderId_,
+                                 .side_ = (order->side_ == BookSide::Bid)
+                                              ? TradeSide::Buy
+                                              : TradeSide::Sell,
+                                 .price_ = trade.price_,
+                                 .quantity_ = fill_qty,
+                                 .is_maker = true});
+    }
+}
+
+/**
+ * @brief Returns a read-only reference to the list of generated fills.
+ *
+ * Provides access to all fills that have occurred during order execution.
+ *
+ * @return A const reference to the vector of Fill objects.
+ */
+const std::vector<Fill> &ExecutionEngine::fills() const { return fills_; }
+
+/**
+ * @brief Clears all recorded fills from the execution engine.
+ *
+ * This method empties the internal `fills_` vector, removing all previously
+ * recorded trade fills. Useful for resetting state between test cases or
+ * simulations.
+ */
+void ExecutionEngine::clear_fills() { fills_.clear(); }
+
+/**
+ * @brief Computes the natural logarithm of (1 + quantity).
+ *
+ * This function uses std::log1p to accurately compute log(1 + qty),
+ * which is especially useful for small values of qty to avoid precision loss.
+ *
+ * @param qty The quantity (x) for which to compute log(1 + x).
+ * @return The natural logarithm of (1 + qty).
+ */
+double ExecutionEngine::f(const double x) { return std::log1p(x); }

--- a/hftengine/core/market_data/book_update.h
+++ b/hftengine/core/market_data/book_update.h
@@ -1,6 +1,6 @@
 /*
- * File: hft_bt_engine/core/market_data/L2Update.h
- * Description: Class defining an L2 update.
+ * File: hft_bt_engine/core/market_data/BookUpdate.h
+ * Description: Class defining a book update.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-24
  * License: Proprietary
@@ -14,7 +14,7 @@
 #include "../types/update_type.h"
 #include "../types/book_side.h"
 
-struct L2Update {
+struct BookUpdate {
     /*
     std::string exchange_;       
     std::string exchangeId_;   

--- a/hftengine/core/orderbook/orderbook.cpp
+++ b/hftengine/core/orderbook/orderbook.cpp
@@ -11,7 +11,7 @@
 # include <iostream>
 
 # include "../types/book_side.h"
-# include "../market_data/l2_update.h"
+# include "../market_data/book_update.h"
 # include "../market_data/trade.h"
 # include "orderbook.h"
 
@@ -22,7 +22,7 @@ void OrderBook::clear() {
 	ask_book_.clear();
 }
 
-void OrderBook::apply_l2_update(const L2Update& update) {
+void OrderBook::apply_book_update(const BookUpdate& update) {
 
 	// throw exception on bad updates
 	if (update.price_ <= 0.0) {
@@ -51,20 +51,50 @@ void OrderBook::apply_l2_update(const L2Update& update) {
 	last_update_ = update.update_type_;
 }
 
+/**
+ * @brief Returns the best (highest) bid price currently in the bid book.
+ *
+ * @return The best bid price, or 0.0 if the bid book is empty.
+ */
 Price OrderBook::best_bid() const {
 	return bid_book_.empty() ? 0.0 : bid_book_.begin()->first;
 }
 
+/**
+ * @brief Returns the best (lowest) ask price currently in the ask book.
+ *
+ * @return The best ask price, or 0.0 if the ask book is empty.
+ */
 Price OrderBook::best_ask() const {
 	return ask_book_.empty() ? 0.0 : ask_book_.begin()->first;
 }
 
+/**
+ * @brief Returns the current mid price.
+ *
+ * Mid price is calculated (best bid + best ask) / 2.0
+ * 
+ * @return The mid price, or 0.0 if the ask book or bid book is empty.
+ */
 Price OrderBook::mid_price() const {
 	if (bid_book_.empty() || ask_book_.empty()) return 0.0;
 	return (best_bid() + best_ask()) / 2.0;
 }
 
-Quantity OrderBook::depth_at(BookSide side, double price) const {
+/**
+ * @brief Returns the total quantity at the given price on one side of the
+ * book.
+ * 
+ * Levels are 0-based:
+ *   - For bids: level 0 = highest bid price, level 1 = second-highest, etc.
+ *   - For asks: level 0 = lowest ask price, level 1 = second-lowest, etc.
+ *
+ * If `level` is negative or exceeds the number of price levels, this returns 0.
+ * @param side  Which side of the book to query (BookSide::Bid or BookSide::Ask)
+ * @param price Price level
+ * @return The quantity f
+ */
+Quantity OrderBook::depth_at(BookSide side, Price price) const {
 	auto it = (side == BookSide::Bid)
 		? bid_book_.find(price)
 		: ask_book_.find(price);
@@ -73,11 +103,101 @@ Quantity OrderBook::depth_at(BookSide side, double price) const {
 		: ((it != ask_book_.end()) ? it->second : 0.0);
 }
 
+/**
+ * @brief Returns the total quantity at the given price level on one side of the
+ * book.
+ *
+ * Levels are 0-based:
+ *   - For bids: level 0 = highest bid price, level 1 = second-highest, etc.
+ *   - For asks: level 0 = lowest ask price, level 1 = second-lowest, etc.
+ *
+ * If `level` is negative or exceeds the number of price levels, this returns 0.
+ *
+ * @param side  Which side of the book to query (BookSide::Bid or BookSide::Ask)
+ * @param level 0-based index of the price level
+ * @return The quantity at that level, or 0 if out of range
+ */
+Quantity OrderBook::depth_at_level(BookSide side, int level) const {
+    if (level < 0) return 0.0;
 
+    // Choose which side of the book
+    if (side == BookSide::Bid) {
+        auto it = bid_book_.begin();
+        auto end = bid_book_.end();
+        for (int i = 0; it != end && i < level; ++it, ++i) {}
+        return (it != end) ? it->second : 0.0;
+    } else {
+        auto it = ask_book_.begin();
+        auto end = ask_book_.end();
+        for (int i = 0; it != end && i < level; ++it, ++i) {}
+        return (it != end) ? it->second : 0.0;
+    }
+}
+
+/**
+ * @brief Returns the price at the given price level on one side of the book.
+ *
+ * Levels are 0-based:
+ *   - For bids: level 0 = highest bid price, level 1 = second-highest, etc.
+ *   - For asks: level 0 = lowest ask price, level 1 = second-lowest, etc.
+ *
+ * If `level` is negative or exceeds the number of price levels, this returns 0.
+ *
+ * @param side  Which side of the book to query (BookSide::Bid or BookSide::Ask)
+ * @param level 0-based index of the price level
+ * @return The price at that level, or 0.0 if it does not exist
+ */
+Price OrderBook::price_at_level(BookSide side, int level) const {  // NEEDS TESTS
+    if (level < 0) return 0.0;
+
+    // Choose which side of the book
+    if (side == BookSide::Bid) {
+        auto it = bid_book_.begin();
+        auto end = bid_book_.end();
+        for (int i = 0; it != end && i < level; ++it, ++i) {
+        }
+        return (it != end) ? it->first : 0.0;
+    } else {
+        auto it = ask_book_.begin();
+        auto end = ask_book_.end();
+        for (int i = 0; it != end && i < level; ++it, ++i) {
+        }
+        return (it != end) ? it->first : 0.0;
+    }
+}
+
+/**
+ * @brief Returns the number of price levels currently in the bid book.
+ *
+ * @return Number of unique bid price levels.
+ */
+int OrderBook::bid_levels() const { return static_cast<int>(bid_book_.size()); }
+
+/**
+ * @brief Returns the number of price levels currently in the ask book.
+ *
+ * @return Number of unique ask price levels.
+ */
+int OrderBook::ask_levels() const { return static_cast<int>(ask_book_.size()); }
+
+/**
+ * @brief Returns if the orderbook is empty or not. 
+ * 
+ * @return true if empty, false if non-empty.
+ */
 bool OrderBook::is_empty() const {
 	return bid_book_.empty() && ask_book_.empty();
 }
 
+/**
+ * @brief Prints the top N levels of the order book to the console.
+ *
+ * This function displays the best `depth` number of price levels on both
+ * the ask and bid sides. Output is printed in human-readable format with
+ * price and corresponding quantity.
+ *
+ * @param depth The number of price levels to display from the top of each side.
+ */
 void OrderBook::print_top_levels(int depth) const {
 	std::cout << "\n--- Order Book Top " << depth << " Levels ---\n";
 

--- a/hftengine/core/orderbook/orderbook.h
+++ b/hftengine/core/orderbook/orderbook.h
@@ -14,7 +14,7 @@
 # include "../types/trade_side.h"
 # include "../types/book_side.h"
 # include "../types/update_type.h"
-# include "../market_data/l2_update.h"
+# include "../market_data/book_update.h"
 # include "../market_data/trade.h"
 
 #pragma once
@@ -33,20 +33,22 @@ public:
     OrderBook();
 
     // Apply incoming L2 book update (price-level based)
-    void apply_l2_update(const L2Update& update);
+    void apply_book_update(const BookUpdate& update);
 
     // Apply trade message to simulate fills
     void apply_trade(const Trade& trade);
-
-    // Check and simulate fills based on current book + trades
-    std::vector<OrderId> check_fills();  // returns filled order IDs
 
     // Book queries
     Price best_bid() const;
     Price best_ask() const;
     Price mid_price() const;
 
-    Quantity depth_at(BookSide side, double price) const;
+    Quantity depth_at(BookSide side, Price price) const;
+    Quantity depth_at_level(BookSide side, int level) const;
+    Price price_at_level(BookSide side, int level) const;
+
+    int bid_levels() const;
+    int ask_levels() const;
 
     // Clear book (e.g., on snapshot)
     void clear();

--- a/hftengine/core/trading/fill.h
+++ b/hftengine/core/trading/fill.h
@@ -22,7 +22,5 @@ struct Fill {
     TradeSide side_;
     Price price_;
     Quantity quantity_;
-
-    double fee;
     bool is_maker;
 };

--- a/hftengine/core/trading/order.h
+++ b/hftengine/core/trading/order.h
@@ -21,6 +21,8 @@ struct Order {
     BookSide side_;
     Price price_;
     Quantity quantity_;
+    Quantity filled_quantity_;
     TimeInForce tif_;
     OrderType orderType_;
+    Quantity queueEst_;
 };

--- a/hftengine/core/types/event_type.h
+++ b/hftengine/core/types/event_type.h
@@ -1,6 +1,6 @@
 /*
  * File: hft_bt_engine/core/market_data/core/update_type.h
- * Description: Enum class defining the two possible L2Update types: Incremental / Snapshot.
+ * Description: Enum class defining the two possible BookUpdate types: Incremental / Snapshot.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-24
  * License: Proprietary
@@ -12,5 +12,5 @@ enum class EventType
 {
     None,
     Trade,
-    L2Update
+    BookUpdate
 };

--- a/hftengine/core/types/queue_model.h
+++ b/hftengine/core/types/queue_model.h
@@ -1,0 +1,19 @@
+/*
+ * File: hftengine/core/types/queue_model.h
+ * Description: Enum class defining the different queue models.
+ * Author: Arvind Rathnashyam
+ * Date: 2025-06-29
+ * License: Proprietary
+ */
+
+#pragma once
+
+enum class QueueModel {
+    RiskAdverse,
+    Prob,
+    PowerProb,
+    PowerProb2,
+    PowerProb3,
+    LogProb,
+    LobProb2
+};

--- a/hftengine/core/types/update_type.h
+++ b/hftengine/core/types/update_type.h
@@ -1,6 +1,6 @@
 /*
  * File: hft_bt_engine/core/market_data/core/update_type.h
- * Description: Enum class defining the two possible L2Update types: Incremental / Snapshot.
+ * Description: Enum class defining the two possible BookUpdate types: Incremental / Snapshot.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-24
  * License: Proprietary

--- a/hftengine/core/types/usings.h
+++ b/hftengine/core/types/usings.h
@@ -13,7 +13,7 @@
 # include <vector>
 
  // Forward declarations
-struct L2Update;
+struct BookUpdate;
 struct Trade;
 struct Order;
 
@@ -23,4 +23,4 @@ using Timestamp = std::uint64_t;
 using OrderId = std::uint64_t;
 using Price = double;
 using Quantity = double;
-using MarketEvent = std::variant<L2Update, Trade>;
+using MarketEvent = std::variant<BookUpdate, Trade>;

--- a/tests/test_book_stream_reader.cpp
+++ b/tests/test_book_stream_reader.cpp
@@ -1,6 +1,6 @@
 /*
- * File: tests/test_l2_stream_reader.cpp
- * Description: Unit tests for hftengine/core/data/readers/l2_stream_reader.cpp.
+ * File: tests/test_book_stream_reader.cpp
+ * Description: Unit tests for hftengine/core/data/readers/book_stream_reader.cpp.
  * Author: Arvind Rathnashyam
  * Date: 2025-06-25
  * License: Proprietary
@@ -10,27 +10,27 @@
 # include <filesystem>
 # include <fstream>
 
-# include "core/data/readers/l2_stream_reader.hpp"
+# include "core/data/readers/book_stream_reader.hpp"
 # include "core/types/book_side.h"
 # include "core/types/update_type.h"
-# include "core/market_data/l2_update.h"
+# include "core/market_data/book_update.h"
 
-TEST_CASE("[L2StreamReader] - Construction", "[l2][reader]") {
+TEST_CASE("[BookStreamReader] - Construction", "[book][reader]") {
     SECTION("Valid tick and lot sizes") {
-        REQUIRE_NOTHROW(L2StreamReader(0.01, 1.0));
+        REQUIRE_NOTHROW(BookStreamReader(0.01, 1.0));
     }
     
     SECTION("Invalid tick size") {
-        REQUIRE_THROWS_AS(L2StreamReader(0.0, 1.0), std::invalid_argument);
+        REQUIRE_THROWS_AS(BookStreamReader(0.0, 1.0), std::invalid_argument);
     }
     
     SECTION("Invalid lot size") {
-        REQUIRE_THROWS_AS(L2StreamReader(0.01, 0.0), std::invalid_argument);
+        REQUIRE_THROWS_AS(BookStreamReader(0.01, 0.0), std::invalid_argument);
     }
 }
 
-TEST_CASE("[L2StreamReader] - CSV Parsing", "[l2][csv]") {
-    const std::string test_file = "test_l2_data.csv";
+TEST_CASE("[BookStreamReader] - CSV Parsing", "[book][csv]") {
+    const std::string test_file = "test_book_update_data.csv";
     {
         std::ofstream out(test_file);
         out << "timestamp,is_snapshot,side,price,amount\n";
@@ -38,11 +38,11 @@ TEST_CASE("[L2StreamReader] - CSV Parsing", "[l2][csv]") {
         out << "123456790,false,ask,101.00,150.0\n";
     }
 
-    L2StreamReader reader(0.01, 1.0);
+    BookStreamReader reader(0.01, 1.0);
     reader.open(test_file);
 
     SECTION("Parses valid bid snapshot correctly") {
-        L2Update update;
+        BookUpdate update;
 
         REQUIRE(reader.parse_next(update));
         REQUIRE(update.timestamp_ == 123456789);
@@ -53,7 +53,7 @@ TEST_CASE("[L2StreamReader] - CSV Parsing", "[l2][csv]") {
     }
 
     SECTION("Parses valid bid update correctly") {
-        L2Update update;
+        BookUpdate update;
         reader.parse_next(update); // each section gets fresh start
 
         REQUIRE(reader.parse_next(update));
@@ -65,7 +65,7 @@ TEST_CASE("[L2StreamReader] - CSV Parsing", "[l2][csv]") {
     }
 
     SECTION("Handles end of file") {
-        L2Update update;
+        BookUpdate update;
         reader.parse_next(update);  // Row 1
         reader.parse_next(update);  // Row 2
         REQUIRE_FALSE(reader.parse_next(update));  // No more data

--- a/tests/test_execution_engine.cpp
+++ b/tests/test_execution_engine.cpp
@@ -1,0 +1,588 @@
+/*
+ * File: tests/test_execution_engine.cpp
+ * Description: Unit tests for
+ * hftengine/core/execution_engine/execution_engine.cpp. Author: Arvind
+ * Rathnashyam Date: 2025-06-27 License: Proprietary
+ */
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+#include "core/execution_engine/execution_engine.h"
+#include "core/market_data/book_update.h"
+#include "core/orderbook/orderbook.h"
+#include "core/types/book_side.h"
+#include "core/types/order_type.h"
+#include "core/types/time_in_force.h"
+#include "core/types/update_type.h"
+#include "core/types/usings.h"
+
+TEST_CASE("[ExecutionEngine] - executes market buy and sell orders",
+          "[execution-engine][market]") {
+    ExecutionEngine engine;
+
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 0,
+                      .localTimestamp_ = 10,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 101.0,
+                      .quantity_ = 2.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 10,
+                      .localTimestamp_ = 20,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 102.0,
+                      .quantity_ = 3.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 20,
+                      .localTimestamp_ = 30,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 100.0,
+                      .quantity_ = 1.5});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 30,
+                      .localTimestamp_ = 40,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 99.0,
+                      .quantity_ = 1.0});
+
+    SECTION("Market buy order fills against ask levels") {
+        auto buy_order =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 1,
+                                          .price_ = 0.0,
+                                          .quantity_ = 4.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTC,
+                                          .orderType_ = OrderType::MARKET});
+
+        engine.execute_market_order(0, TradeSide::Buy, buy_order);
+
+        const auto &fills = engine.fills();
+        REQUIRE(buy_order->filled_quantity_ == 4.0);
+        REQUIRE(fills.size() == 2);
+        REQUIRE(fills[0].price_ == 101.0);
+        REQUIRE(fills[0].quantity_ == 2.0);
+        REQUIRE(fills[0].side_ == TradeSide::Buy);
+        REQUIRE(fills[1].price_ == 102.0);
+        REQUIRE(fills[1].quantity_ == 2.0);
+        REQUIRE(fills[1].side_ == TradeSide::Buy);
+    }
+
+    SECTION("Market sell order fills against bid levels") {
+        auto sell_order =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 2,
+                                          .price_ = 0.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTC,
+                                          .orderType_ = OrderType::MARKET});
+
+        engine.execute_market_order(0, TradeSide::Sell, sell_order);
+
+        const auto &fills = engine.fills();
+        REQUIRE(sell_order->filled_quantity_ == 2.0);
+        REQUIRE(fills.size() == 2);
+        REQUIRE(fills[0].price_ == 100.0);
+        REQUIRE(fills[0].quantity_ == 1.5);
+        REQUIRE(fills[0].side_ == TradeSide::Sell);
+        REQUIRE(fills[1].price_ == 99.0);
+        REQUIRE(fills[1].quantity_ == 0.5);
+        REQUIRE(fills[1].side_ == TradeSide::Sell);
+    }
+}
+
+TEST_CASE("[ExecutionEngine] - executes limit fill-or-kill buy and sell orders",
+          "[execution-engine][FOK]") {
+    ExecutionEngine engine;
+
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 0,
+                      .localTimestamp_ = 10,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 101.0,
+                      .quantity_ = 2.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 10,
+                      .localTimestamp_ = 20,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 102.0,
+                      .quantity_ = 3.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 20,
+                      .localTimestamp_ = 30,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 100.0,
+                      .quantity_ = 1.5});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 30,
+                      .localTimestamp_ = 40,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 99.0,
+                      .quantity_ = 1.0});
+
+    SECTION("Limit buy fill-or-kill order fills against ask levels") {
+        auto buy_order =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 1,
+                                          .price_ = 101.5,
+                                          .quantity_ = 3.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::FOK,
+                                          .orderType_ = OrderType::LIMIT});
+        REQUIRE(engine.execute_fok_order(0, TradeSide::Buy, buy_order) ==
+                false);
+
+        const auto &fills = engine.fills();
+        REQUIRE(buy_order->filled_quantity_ == 0.0);
+        REQUIRE(fills.size() == 0);
+    }
+    SECTION("Limit sell fill-or-kill order fills against bid levels") {
+        auto sell_order =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 2,
+                                          .price_ = 99.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::FOK,
+                                          .orderType_ = OrderType::LIMIT});
+        REQUIRE(engine.execute_fok_order(0, TradeSide::Sell, sell_order) ==
+                true);
+
+        const auto &fills = engine.fills();
+        REQUIRE(sell_order->filled_quantity_ == 2.0);
+        REQUIRE(fills.size() == 2);
+        REQUIRE(fills[0].price_ == 100.0);
+        REQUIRE(fills[0].quantity_ == 1.5);
+        REQUIRE(fills[1].price_ == 99.0);
+        REQUIRE(fills[1].quantity_ == 0.5);
+    }
+}
+
+TEST_CASE(
+    "[ExecutionEngine] - executes limit immediate-or-cancel buy and sell ",
+    "[execution-engine][IOC]") {
+    ExecutionEngine engine;
+
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 0,
+                      .localTimestamp_ = 10,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 101.0,
+                      .quantity_ = 2.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 10,
+                      .localTimestamp_ = 20,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 102.0,
+                      .quantity_ = 3.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 20,
+                      .localTimestamp_ = 30,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 100.0,
+                      .quantity_ = 1.5});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 30,
+                      .localTimestamp_ = 40,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 99.0,
+                      .quantity_ = 1.0});
+
+    SECTION("Limit buy immediate-or-cancel order fills against ask levels") {
+        auto buy_order =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 1,
+                                          .price_ = 101.5,
+                                          .quantity_ = 3.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::IOC,
+                                          .orderType_ = OrderType::LIMIT});
+        REQUIRE(engine.execute_ioc_order(0, TradeSide::Buy, buy_order) == true);
+
+        const auto &fills = engine.fills();
+        REQUIRE(buy_order->filled_quantity_ == 2.0);
+        REQUIRE(fills.size() == 1);
+        REQUIRE(fills[0].price_ == 101.0);
+        REQUIRE(fills[0].quantity_ == 2.0);
+    }
+    SECTION("Limit sell immediate-or-cancel order fills against bid levels") {
+        auto sell_order =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 2,
+                                          .price_ = 99.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::IOC,
+                                          .orderType_ = OrderType::LIMIT});
+        REQUIRE(engine.execute_ioc_order(0, TradeSide::Sell, sell_order) ==
+                true);
+
+        const auto &fills = engine.fills();
+        REQUIRE(sell_order->filled_quantity_ == 2.0);
+        REQUIRE(fills.size() == 2);
+        REQUIRE(fills[0].price_ == 100.0);
+        REQUIRE(fills[0].quantity_ == 1.5);
+        REQUIRE(fills[1].price_ == 99.0);
+        REQUIRE(fills[1].quantity_ == 0.5);
+    }
+}
+
+TEST_CASE("[ExecutionEngine] - places limit GTX orders ",
+          "[execution-engine][GTX]") {
+    ExecutionEngine engine;
+
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 0,
+                      .localTimestamp_ = 10,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 101.0,
+                      .quantity_ = 2.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 10,
+                      .localTimestamp_ = 20,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 102.0,
+                      .quantity_ = 3.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 20,
+                      .localTimestamp_ = 30,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 100.0,
+                      .quantity_ = 1.5});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 30,
+                      .localTimestamp_ = 40,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 99.0,
+                      .quantity_ = 1.0});
+
+    SECTION("Places limit GTX buy order against bid levels") {
+        auto buy_order_1 =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 1,
+                                          .side_ = BookSide::Bid,
+                                          .price_ = 101.5,
+                                          .quantity_ = 3.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        REQUIRE(engine.place_gtx_order(0, buy_order_1) == false);
+        const auto &fills_1 = engine.fills();
+        REQUIRE(fills_1.size() == 0);
+
+        auto buy_order_2 =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 1,
+                                          .side_ = BookSide::Bid,
+                                          .price_ = 98.0,
+                                          .quantity_ = 3.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        REQUIRE(engine.place_gtx_order(0, buy_order_2) == true);
+        const auto &fills_2 = engine.fills();
+        REQUIRE(fills_2.size() == 0);
+    }
+    SECTION("Places limit GTX sell order against ask levels") {
+        auto sell_order_1 =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 2,
+                                          .side_ = BookSide::Ask,
+                                          .price_ = 99.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT});
+        REQUIRE(engine.place_gtx_order(0, sell_order_1) == false);
+        const auto &fills_1 = engine.fills();
+        REQUIRE(fills_1.size() == 0);
+
+        auto sell_order_2 =
+            std::make_shared<Order>(Order{.timestamp_ = 50,
+                                          .orderId_ = 2,
+                                          .side_ = BookSide::Ask,
+                                          .price_ = 102.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT});
+        REQUIRE(engine.place_gtx_order(0, sell_order_2) == true);
+        REQUIRE(sell_order_2->queueEst_ == 3.0);
+        const auto &fills_2 = engine.fills();
+        REQUIRE(fills_2.size() == 0);
+    }
+}
+
+TEST_CASE("[ExecutionEngine] - queue estimation", "[execution-engine][queue]") {
+    ExecutionEngine engine;
+
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 10,
+                      .localTimestamp_ = 20,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Ask,
+                      .price_ = 102.0,
+                      .quantity_ = 3.0});
+    engine.handle_book_update(
+        0, BookUpdate{.timestamp_ = 30,
+                      .localTimestamp_ = 40,
+                      .update_type_ = UpdateType::Incremental,
+                      .side_ = BookSide::Bid,
+                      .price_ = 99.0,
+                      .quantity_ = 1.0});
+
+    auto buy_order_1 =
+        std::make_shared<Order>(Order{.timestamp_ = 50,
+                                      .orderId_ = 1,
+                                      .side_ = BookSide::Bid,
+                                      .price_ = 99.0,
+                                      .quantity_ = 3.0,
+                                      .filled_quantity_ = 0.0,
+                                      .tif_ = TimeInForce::GTX,
+                                      .orderType_ = OrderType::LIMIT,
+                                      .queueEst_ = 0.0});
+    auto sell_order_1 =
+        std::make_shared<Order>(Order{.timestamp_ = 50,
+                                      .orderId_ = 2,
+                                      .side_ = BookSide::Ask,
+                                      .price_ = 102.0,
+                                      .quantity_ = 1.0,
+                                      .filled_quantity_ = 0.0,
+                                      .tif_ = TimeInForce::GTX,
+                                      .orderType_ = OrderType::LIMIT,
+                                      .queueEst_ = 0.0});
+
+    SECTION("Initial queue estimation") {
+        // placed at the end of existing depth at price level
+        engine.place_gtx_order(0, buy_order_1);
+        engine.place_gtx_order(0, sell_order_1);
+        REQUIRE(buy_order_1->queueEst_ == 1.0);
+        REQUIRE(sell_order_1->queueEst_ == 3.0);
+    }
+    SECTION("Queue estimation updates") {
+        // f(x) = ln(1+x)
+        engine.place_gtx_order(0, buy_order_1);
+        engine.place_gtx_order(0, sell_order_1);
+
+        engine.handle_book_update(
+            0, BookUpdate{.timestamp_ = 60,
+                          .localTimestamp_ = 70,
+                          .update_type_ = UpdateType::Incremental,
+                          .side_ = BookSide::Bid,
+                          .price_ = 99.0,
+                          .quantity_ = 0.2});
+
+        engine.handle_book_update(
+            0, BookUpdate{.timestamp_ = 70,
+                          .localTimestamp_ = 80,
+                          .update_type_ = UpdateType::Incremental,
+                          .side_ = BookSide::Ask,
+                          .price_ = 102.0,
+                          .quantity_ = 5.0});
+        // buy order at bottom of queue, queue est. should decrease by delta
+        REQUIRE(buy_order_1->queueEst_ == Catch::Approx(0.2).margin(1e-8));
+        // sell order position remains unchanged
+        REQUIRE(sell_order_1->queueEst_ == Catch::Approx(3.0).margin(1e-8));
+
+        engine.handle_book_update(
+            0, BookUpdate{.timestamp_ = 80,
+                          .localTimestamp_ = 90,
+                          .update_type_ = UpdateType::Incremental,
+                          .side_ = BookSide::Ask,
+                          .price_ = 102.0,
+                          .quantity_ = 1.0});
+        REQUIRE(sell_order_1->queueEst_ ==
+                Catch::Approx(1.0 / 3.0).margin(1e-8));
+        engine.handle_book_update(
+            0, BookUpdate{.timestamp_ = 90,
+                          .localTimestamp_ = 100,
+                          .update_type_ = UpdateType::Incremental,
+                          .side_ = BookSide::Ask,
+                          .price_ = 102.0,
+                          .quantity_ = 0.5});
+        REQUIRE(sell_order_1->queueEst_ == 0.0);
+    }
+}
+
+TEST_CASE("[ExecutionEngine] - processes trades", "[execution-engine][trade]") {
+    SECTION("Full execution of bid order when sufficient trade size") {
+        ExecutionEngine engine;
+
+        auto buy_order =
+            std::make_shared<Order>(Order{.timestamp_ = 10,
+                                          .orderId_ = 1,
+                                          .side_ = BookSide::Bid,
+                                          .price_ = 100.0,
+                                          .quantity_ = 1.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        engine.place_gtx_order(0, buy_order);
+        REQUIRE(buy_order->queueEst_ == 0.0);
+
+        engine.handle_trade(0, Trade{.timestamp_ = 20,
+                                     .local_timestamp_ = 25,
+                                     .side_ = TradeSide::Sell,
+                                     .price_ = 100.0,
+                                     .quantity_ = 1.0,
+                                     .orderId_ = 999});
+
+        REQUIRE(buy_order->filled_quantity_ == buy_order->quantity_);
+
+        const auto &fills = engine.fills();
+        REQUIRE(fills.size() == 1);
+        REQUIRE(fills[0].price_ == 100.0);
+        REQUIRE(fills[0].quantity_ == 1.0);
+        REQUIRE(fills[0].side_ == TradeSide::Buy);
+        REQUIRE(fills[0].orderId_ == 1);
+        REQUIRE(fills[0].is_maker == true);
+        REQUIRE(buy_order->filled_quantity_ == 1.0);
+
+        engine.clear_fills();
+        REQUIRE(fills.size() == 0);
+
+        auto sell_order =
+            std::make_shared<Order>(Order{.timestamp_ = 30,
+                                          .orderId_ = 2,
+                                          .side_ = BookSide::Ask,
+                                          .price_ = 102.0,
+                                          .quantity_ = 1.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        engine.place_gtx_order(0, sell_order);
+
+        engine.handle_trade(0, Trade{.timestamp_ = 40,
+                                     .local_timestamp_ = 45,
+                                     .side_ = TradeSide::Buy,
+                                     .price_ = 102.0,
+                                     .quantity_ = 3.0,
+                                     .orderId_ = 999});
+        REQUIRE(fills.size() == 1);
+        REQUIRE(fills[0].price_ == 102.0);
+        REQUIRE(fills[0].quantity_ == 1.0);
+        REQUIRE(fills[0].side_ == TradeSide::Sell);
+        REQUIRE(fills[0].orderId_ == 2);
+        REQUIRE(fills[0].is_maker == true);
+        REQUIRE(buy_order->filled_quantity_ == 1.0);
+    }
+    SECTION("Partially fills order when trade quantity is smaller") {
+        ExecutionEngine engine;
+
+        auto buy_order =
+            std::make_shared<Order>(Order{.timestamp_ = 10,
+                                          .orderId_ = 1,
+                                          .side_ = BookSide::Bid,
+                                          .price_ = 101.0,
+                                          .quantity_ = 1.5,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        engine.place_gtx_order(0, buy_order);
+        engine.handle_trade(0, Trade{.timestamp_ = 20,
+                                     .local_timestamp_ = 21,
+                                     .side_ = TradeSide::Sell,
+                                     .price_ = 101.0,
+                                     .quantity_ = 1.0,
+                                     .orderId_ = 1000});
+
+        REQUIRE(buy_order->filled_quantity_ == 1.0);
+        REQUIRE(buy_order->queueEst_ == 0.0);
+        REQUIRE(engine.fills().size() == 1);
+
+        engine.clear_fills();
+        REQUIRE(engine.fills().size() == 0);
+
+        auto sell_order =
+            std::make_shared<Order>(Order{.timestamp_ = 30,
+                                          .orderId_ = 1,
+                                          .side_ = BookSide::Ask,
+                                          .price_ = 103.0,
+                                          .quantity_ = 3.5,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        engine.place_gtx_order(0, sell_order);
+        engine.handle_trade(0, Trade{.timestamp_ = 40,
+                                     .local_timestamp_ = 41,
+                                     .side_ = TradeSide::Buy,
+                                     .price_ = 103.0,
+                                     .quantity_ = 2.0,
+                                     .orderId_ = 1000});
+
+        REQUIRE(sell_order->filled_quantity_ == 2.0);
+        REQUIRE(sell_order->queueEst_ == 0.0);
+        REQUIRE(engine.fills().size() == 1);
+
+    }
+    SECTION("Does not fill if trade timestamp is before order") {
+        ExecutionEngine engine;
+
+        auto buy_order =
+            std::make_shared<Order>(Order{.timestamp_ = 30,
+                                          .orderId_ = 2,
+                                          .side_ = BookSide::Bid,
+                                          .price_ = 101.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        engine.place_gtx_order(0, buy_order);
+        engine.handle_trade(0, Trade{.timestamp_ = 20,
+                                     .local_timestamp_ = 21,
+                                     .side_ = TradeSide::Sell,
+                                     .price_ = 101.0,
+                                     .quantity_ = 1.0,
+                                     .orderId_ = 1234});
+
+        REQUIRE(buy_order->filled_quantity_ == 0.0);
+        REQUIRE(engine.fills().empty());
+
+        auto sell_order =
+            std::make_shared<Order>(Order{.timestamp_ = 60,
+                                          .orderId_ = 2,
+                                          .side_ = BookSide::Ask,
+                                          .price_ = 101.0,
+                                          .quantity_ = 2.0,
+                                          .filled_quantity_ = 0.0,
+                                          .tif_ = TimeInForce::GTX,
+                                          .orderType_ = OrderType::LIMIT,
+                                          .queueEst_ = 0.0});
+        engine.place_gtx_order(0, buy_order);
+        engine.handle_trade(0, Trade{.timestamp_ = 40,
+                                     .local_timestamp_ = 21,
+                                     .side_ = TradeSide::Buy,
+                                     .price_ = 101.0,
+                                     .quantity_ = 1.0,
+                                     .orderId_ = 1234});
+
+        REQUIRE(buy_order->filled_quantity_ == 0.0);
+        REQUIRE(engine.fills().empty());
+    }
+}

--- a/tests/test_orderbook.cpp
+++ b/tests/test_orderbook.cpp
@@ -8,47 +8,56 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-# include "core/orderbook/orderbook.h"
-# include "core/types/update_type.h"
-# include "core/types/book_side.h"
-# include "core/market_data/l2_update.h"
+#include "core/market_data/book_update.h"
+#include "core/orderbook/orderbook.h"
+#include "core/types/book_side.h"
+#include "core/types/update_type.h"
 
 TEST_CASE("[OrderBook] - Initial State", "[orderbook][init]") {
     OrderBook book;
-    
+
     REQUIRE(book.is_empty());
     REQUIRE(book.best_bid() == 0.0);
     REQUIRE(book.best_ask() == 0.0);
     REQUIRE(book.mid_price() == 0.0);
 }
 
-TEST_CASE("[OrderBook] - L2 Update Processing", "[orderbook][updates]") {
+TEST_CASE("[OrderBook] - Book Update Processing", "[orderbook][updates]") {
     OrderBook book;
 
     SECTION("Snapshot updates initialize book") {
-        L2Update snapshot_bid{ 0, 90, UpdateType::Snapshot, BookSide::Bid, 100.0, 500.0 };
-        book.apply_l2_update(snapshot_bid);
+        BookUpdate snapshot_bid{
+            0, 90, UpdateType::Snapshot, BookSide::Bid, 100.0, 500.0};
+        book.apply_book_update(snapshot_bid);
 
         REQUIRE_FALSE(book.is_empty());
         REQUIRE(book.best_bid() == 100.0);
         REQUIRE(book.best_ask() == 0.0);
         REQUIRE(book.depth_at(BookSide::Bid, 100.0) == 500.0);
+        REQUIRE(book.depth_at_level(BookSide::Bid, 0) == 500.0);
     }
 
     SECTION("Incremental updates modify existing levels") {
         // Setup with snapshot
-        book.apply_l2_update({ 10, 100, UpdateType::Snapshot, BookSide::Ask, 101.0, 200.0 });
+        book.apply_book_update(
+            {10, 100, UpdateType::Snapshot, BookSide::Ask, 101.0, 200.0});
 
         // Incremental update
-        book.apply_l2_update({ 20, 110, UpdateType::Incremental, BookSide::Ask, 101.0, 150.0 });
+        book.apply_book_update(
+            {20, 110, UpdateType::Incremental, BookSide::Ask, 101.0, 150.0});
+
         REQUIRE(book.depth_at(BookSide::Ask, 101.0) == 150.0);
+        REQUIRE(book.depth_at_level(BookSide::Ask, 0) == 150.0);
     }
 
     SECTION("Zero quantity removes price level") {
-        book.apply_l2_update({ 30, 120, UpdateType::Snapshot, BookSide::Bid, 99.0, 300.0 });
-        book.apply_l2_update({ 40, 130, UpdateType::Incremental, BookSide::Bid, 99.0, 0.0 });
+        book.apply_book_update(
+            {30, 120, UpdateType::Snapshot, BookSide::Bid, 99.0, 300.0});
+        book.apply_book_update(
+            {40, 130, UpdateType::Incremental, BookSide::Bid, 99.0, 0.0});
 
         REQUIRE(book.depth_at(BookSide::Bid, 99.0) == 0.0);
+        REQUIRE(book.depth_at_level(BookSide::Bid, 0) == 0.0);
         REQUIRE(book.is_empty());
     }
 }
@@ -58,38 +67,78 @@ TEST_CASE("[OrderBook] - Price Level Priority", "[orderbook][priority]") {
 
     // snapshots
     SECTION("Bid book is sorted in descending order from snapshots") {
-        book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Bid, 100.0, 100.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Bid, 99.0, 200.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Bid, 101.0, 300.0 });
+        book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Bid, 100.0, 100.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Bid, 99.0, 200.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Bid, 101.0, 300.0});
 
-        REQUIRE(book.best_bid() == 101.0);  // Highest bid first
+        REQUIRE(book.best_bid() == 101.0); // Highest bid first
+
+        REQUIRE(book.depth_at_level(BookSide::Bid, 0) == 300.0);
+        REQUIRE(book.depth_at_level(BookSide::Bid, 1) == 100.0);
+        REQUIRE(book.depth_at_level(BookSide::Bid, 2) == 200.0);
+
+        REQUIRE(book.bid_levels() == 3);
+        REQUIRE(book.ask_levels() == 0);
     }
 
     SECTION("Ask book is sorted in ascending order from snapshots") {
-        book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Ask, 101.0, 100.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Ask, 102.0, 200.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Ask, 100.0, 300.0 });
+        book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Ask, 101.0, 100.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Ask, 102.0, 200.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Ask, 100.0, 300.0});
 
-        REQUIRE(book.best_ask() == 100.0);  // Lowest ask first
+        REQUIRE(book.best_ask() == 100.0); // Lowest ask first
+
+        REQUIRE(book.depth_at_level(BookSide::Ask, 0) == 300.0);
+        REQUIRE(book.depth_at_level(BookSide::Ask, 1) == 100.0);
+        REQUIRE(book.depth_at_level(BookSide::Ask, 2) == 200.0);
+
+        REQUIRE(book.bid_levels() == 0);
+        REQUIRE(book.ask_levels() == 3);
     }
 
     book.clear();
 
     // incremental updates
     SECTION("Bid book is sorted in descending order from incremental updates") {
-        book.apply_l2_update({ 0, 0, UpdateType::Incremental, BookSide::Bid, 100.0, 100.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Incremental, BookSide::Bid, 99.0, 200.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Incremental, BookSide::Bid, 101.0, 300.0 });
+        book.apply_book_update(
+            {0, 0, UpdateType::Incremental, BookSide::Bid, 100.0, 100.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Incremental, BookSide::Bid, 99.0, 200.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Incremental, BookSide::Bid, 101.0, 300.0});
 
-        REQUIRE(book.best_bid() == 101.0);  // Highest bid first
+        REQUIRE(book.best_bid() == 101.0); // Highest bid first
+
+        REQUIRE(book.depth_at_level(BookSide::Bid, 0) == 300.0);
+        REQUIRE(book.depth_at_level(BookSide::Bid, 1) == 100.0);
+        REQUIRE(book.depth_at_level(BookSide::Bid, 2) == 200.0);
+
+        REQUIRE(book.bid_levels() == 3);
+        REQUIRE(book.ask_levels() == 0);
     }
 
     SECTION("Ask book is sorted in ascending order from incremental updates") {
-        book.apply_l2_update({ 0, 0, UpdateType::Incremental, BookSide::Ask, 102.0, 100.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Incremental, BookSide::Ask, 104.0, 200.0 });
-        book.apply_l2_update({ 0, 0, UpdateType::Incremental, BookSide::Ask, 103.0, 300.0 });
+        book.apply_book_update(
+            {0, 0, UpdateType::Incremental, BookSide::Ask, 102.0, 100.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Incremental, BookSide::Ask, 104.0, 200.0});
+        book.apply_book_update(
+            {0, 0, UpdateType::Incremental, BookSide::Ask, 103.0, 300.0});
 
-        REQUIRE(book.best_ask() == 102.0);  // Lowest ask first
+        REQUIRE(book.best_ask() == 102.0); // Lowest ask first
+
+        REQUIRE(book.depth_at_level(BookSide::Ask, 0) == 100.0);
+        REQUIRE(book.depth_at_level(BookSide::Ask, 1) == 300.0);
+        REQUIRE(book.depth_at_level(BookSide::Ask, 2) == 200.0);
+
+        REQUIRE(book.bid_levels() == 0);
+        REQUIRE(book.ask_levels() == 3);
     }
 }
 
@@ -97,10 +146,12 @@ TEST_CASE("[OrderBook] - Edge Cases", "[orderbook][edge]") {
     OrderBook book;
 
     SECTION("Zero price handling") {
-        REQUIRE_THROWS(book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Bid, 0.0, 100.0 }));
+        REQUIRE_THROWS(book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Bid, 0.0, 100.0}));
     }
 
     SECTION("Negative price rejection") {
-        REQUIRE_THROWS(book.apply_l2_update({ 0, 0, UpdateType::Snapshot, BookSide::Ask, -1.0, 100.0 }));
+        REQUIRE_THROWS(book.apply_book_update(
+            {0, 0, UpdateType::Snapshot, BookSide::Ask, -1.0, 100.0}));
     }
 }


### PR DESCRIPTION
Order matching is now implemented for the following order types : 
- market
- limit IOC
- limit FOK
- limit GTX.
Probability queue estimation logic is also implemented and runs on every book update. Limit GTX matching runs on every trade update. 