### PR TITLE
constant latency model for orders

### DIFF
--- a/hftengine/core/execution_engine/execution_engine.cpp
+++ b/hftengine/core/execution_engine/execution_engine.cpp
@@ -91,7 +91,7 @@ bool ExecutionEngine::cancel_order(int asset_id, const OrderId &orderId,
                      active_vec.end());
     // Remove from global orders map
     orders_.erase(it);
-    Timestamp local_timestamp = current_timestamp + order_response_latency_us;
+    Timestamp local_timestamp = current_timestamp + order_response_latency_us_;
     order_updates_.emplace_back(
         OrderUpdate{.exch_timestamp_ = current_timestamp,
                     .local_timestamp_ = local_timestamp,
@@ -158,7 +158,7 @@ void ExecutionEngine::execute_market_order(int asset_id, TradeSide side,
                 Fill{.asset_id_ = asset_id,
                      .exch_timestamp_ = order->exch_timestamp_,
                      .local_timestamp_ =
-                         order->exch_timestamp_ + order_response_latency_us,
+                         order->exch_timestamp_ + order_response_latency_us_,
                      .orderId_ = order->orderId_,
                      .side_ = side,
                      .price_ = level_price,
@@ -168,7 +168,7 @@ void ExecutionEngine::execute_market_order(int asset_id, TradeSide side,
             order_updates_.emplace_back(
                 OrderUpdate{.exch_timestamp_ = order->exch_timestamp_,
                             .local_timestamp_ = order->exch_timestamp_ +
-                                                order_response_latency_us,
+                                                order_response_latency_us_,
                             .asset_id_ = asset_id,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::Fill,
@@ -178,7 +178,7 @@ void ExecutionEngine::execute_market_order(int asset_id, TradeSide side,
                 Fill{.asset_id_ = asset_id,
                      .exch_timestamp_ = order->exch_timestamp_,
                      .local_timestamp_ =
-                         order->exch_timestamp_ + order_response_latency_us,
+                         order->exch_timestamp_ + order_response_latency_us_,
                      .orderId_ = order->orderId_,
                      .side_ = side,
                      .price_ = level_price,
@@ -188,7 +188,7 @@ void ExecutionEngine::execute_market_order(int asset_id, TradeSide side,
             order_updates_.emplace_back(
                 OrderUpdate{.exch_timestamp_ = order->exch_timestamp_,
                             .local_timestamp_ = order->exch_timestamp_ +
-                                                order_response_latency_us,
+                                                order_response_latency_us_,
                             .asset_id_ = asset_id,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::Fill,
@@ -259,7 +259,7 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
                 Fill{.asset_id_ = asset_id,
                      .exch_timestamp_ = order->exch_timestamp_,
                      .local_timestamp_ =
-                         order->exch_timestamp_ + order_response_latency_us,
+                         order->exch_timestamp_ + order_response_latency_us_,
                      .orderId_ = order->orderId_,
                      .side_ = TradeSide::Buy,
                      .price_ = level_price,
@@ -269,7 +269,7 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
             order_updates_.emplace_back(
                 OrderUpdate{.exch_timestamp_ = order->exch_timestamp_,
                             .local_timestamp_ = order->exch_timestamp_ +
-                                                order_response_latency_us,
+                                                order_response_latency_us_,
                             .asset_id_ = asset_id,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::Fill,
@@ -279,7 +279,7 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
                 Fill{.asset_id_ = asset_id,
                      .exch_timestamp_ = order->exch_timestamp_,
                      .local_timestamp_ =
-                         order->exch_timestamp_ + order_response_latency_us,
+                         order->exch_timestamp_ + order_response_latency_us_,
                      .orderId_ = order->orderId_,
                      .side_ = TradeSide::Buy,
                      .price_ = level_price,
@@ -289,7 +289,7 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
             order_updates_.emplace_back(
                 OrderUpdate{.exch_timestamp_ = order->exch_timestamp_,
                             .local_timestamp_ = order->exch_timestamp_ +
-                                                order_response_latency_us,
+                                                order_response_latency_us_,
                             .asset_id_ = asset_id,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::Fill,
@@ -344,7 +344,7 @@ bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
             Fill fill = {.asset_id_ = asset_id,
                          .exch_timestamp_ = order->exch_timestamp_,
                          .local_timestamp_ =
-                             order->exch_timestamp_ + order_response_latency_us,
+                             order->exch_timestamp_ + order_response_latency_us_,
                          .orderId_ = order->orderId_,
                          .side_ = side,
                          .price_ = level_price,
@@ -356,7 +356,7 @@ bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
             order_updates_.emplace_back(
                 OrderUpdate{.exch_timestamp_ = order->exch_timestamp_,
                             .local_timestamp_ = order->exch_timestamp_ +
-                                                order_response_latency_us,
+                                                order_response_latency_us_,
                             .asset_id_ = asset_id,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::Fill,
@@ -368,7 +368,7 @@ bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
                 Fill{.asset_id_ = asset_id,
                      .exch_timestamp_ = order->exch_timestamp_,
                      .local_timestamp_ =
-                         order->exch_timestamp_ + order_response_latency_us,
+                         order->exch_timestamp_ + order_response_latency_us_,
                      .orderId_ = order->orderId_,
                      .side_ = side,
                      .price_ = level_price,
@@ -377,7 +377,7 @@ bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
             order_updates_.emplace_back(
                 OrderUpdate{.exch_timestamp_ = order->exch_timestamp_,
                             .local_timestamp_ = order->exch_timestamp_ +
-                                                order_response_latency_us,
+                                                order_response_latency_us_,
                             .asset_id_ = asset_id,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::Fill,
@@ -438,7 +438,7 @@ bool ExecutionEngine::place_gtx_order(int asset_id,
     active_orders_[asset_id].push_back(order);
     order_updates_.emplace_back(OrderUpdate{
         .exch_timestamp_ = order->exch_timestamp_,
-        .local_timestamp_ = order->exch_timestamp_ + order_response_latency_us,
+        .local_timestamp_ = order->exch_timestamp_ + order_response_latency_us_,
         .asset_id_ = asset_id,
         .orderId_ = order->orderId_,
         .event_type_ = OrderEventType::Acknowledged});
@@ -596,7 +596,7 @@ void ExecutionEngine::handle_trade(int asset_id, const Trade &trade) {
         order_updates_.emplace_back(
             OrderUpdate{.exch_timestamp_ = trade.exch_timestamp_,
                         .local_timestamp_ =
-                            trade.exch_timestamp_ + order_response_latency_us,
+                            trade.exch_timestamp_ + order_response_latency_us_,
                         .asset_id_ = asset_id,
                         .orderId_ = order->orderId_,
                         .event_type_ = OrderEventType::Fill,
@@ -605,7 +605,7 @@ void ExecutionEngine::handle_trade(int asset_id, const Trade &trade) {
             Fill{.asset_id_ = asset_id,
                  .exch_timestamp_ = trade.exch_timestamp_,
                  .local_timestamp_ =
-                     trade.exch_timestamp_ + order_response_latency_us,
+                     trade.exch_timestamp_ + order_response_latency_us_,
                  .orderId_ = order->orderId_,
                  .side_ = (order->side_ == BookSide::Bid) ? TradeSide::Buy
                                                           : TradeSide::Sell,
@@ -664,3 +664,21 @@ void ExecutionEngine::clear_fills() { fills_.clear(); }
  * @return The natural logarithm of (1 + qty).
  */
 double ExecutionEngine::f(const double x) { return std::log1p(x); }
+
+/**
+ * @brief Sets the order entry latency in microseconds
+ * @param latency in microseconds
+ */
+void ExecutionEngine::set_order_entry_latency_us(
+    const Microseconds latency_us) {
+    order_entry_latency_us_ = latency_us;
+}
+
+/**
+ * @brief Sets the order response latency in microseconds
+ * @param latency in microseconds
+ */
+void ExecutionEngine::set_order_response_latency_us(
+    const Microseconds latency_us) {
+    order_response_latency_us_ = latency_us;
+}

--- a/hftengine/core/execution_engine/execution_engine.h
+++ b/hftengine/core/execution_engine/execution_engine.h
@@ -56,9 +56,12 @@ class ExecutionEngine {
 
     double f(const double x);
 
+    void set_order_entry_latency_us(const Microseconds latency_us);
+    void set_order_response_latency_us(const Microseconds latency_us);
+
   private:
-    std::uint64_t order_entry_latency_us = 1000;
-    std::uint64_t order_response_latency_us = 1000;
+    std::uint64_t order_entry_latency_us_ = 1000;
+    std::uint64_t order_response_latency_us_ = 1000;
 
     std::unordered_map<int, OrderBook> orderbooks_;
 

--- a/hftengine/core/strategy/strategy.h
+++ b/hftengine/core/strategy/strategy.h
@@ -1,0 +1,24 @@
+/*
+ * File: hftengine/core/strategy/strategy.cpp
+ * Description: Base class for strategies. 
+ * Author: Arvind Rathnashyam
+ * Date: 2025-08-09
+ * License: Proprietary
+ */
+
+#pragma once 
+
+#include <vector>
+#include <memory>
+
+#include "../types/usings.h"
+
+class Strategy {
+  public:
+    explicit Strategy() : capital_(0.0){};
+
+    virtual ~Strategy() = default;
+
+    virtual void initialize() = 0;
+    virtual void on_interval() = 0;
+};

--- a/hftengine/core/trading/backtest_engine.cpp
+++ b/hftengine/core/trading/backtest_engine.cpp
@@ -7,11 +7,6 @@
  * License: Proprietary
  */
 
-/*
- * Process fills needed to properly unit test elapse()
- *
- **/
-
 #include <cstdint>
 #include <iostream>
 #include <map>
@@ -397,7 +392,8 @@ std::vector<Order> BacktestEngine::orders(int asset_id) {
 
 double BacktestEngine::cash() { return cash_balance; }
 
-double BacktestEngine::equity() { double value = cash_balance;
+double BacktestEngine::equity() {
+    double value = cash_balance;
     for (auto &[asset_id, pos] : local_position_) {
         value += pos * local_orderbooks_[asset_id].mid_price();
     }
@@ -444,6 +440,32 @@ Depth BacktestEngine::depth(int asset_id) {
  */
 Timestamp BacktestEngine::current_time() { return current_time_us_; }
 
-const Microseconds BacktestEngine::order_entry_latency() const { return order_entry_latency_us; }
+/**
+ * @brief Sets the order entry latency in microseconds
+ * @param Latency in microseconds
+ */
+void BacktestEngine::set_order_entry_latency(const Microseconds latency) {
+    order_entry_latency_us = latency;
+    execution_engine_.set_order_entry_latency_us(latency);
+}
 
-const Microseconds BacktestEngine::order_response_latency() const { return order_response_latency_us; }
+/**
+ * @brief Sets ther order response latency in microseconds
+ * @param Latency in microseconds
+ */
+void BacktestEngine::set_order_response_latency(const Microseconds latency) {
+    order_response_latency_us = latency;
+    execution_engine_.set_order_response_latency_us(latency);
+}
+
+const Microseconds BacktestEngine::order_entry_latency() const {
+    return order_entry_latency_us;
+}
+
+const Microseconds BacktestEngine::order_response_latency() const {
+    return order_response_latency_us;
+}
+
+const Microseconds BacktestEngine::market_feed_latency() const {
+    return market_feed_latency_us;
+}

--- a/hftengine/core/trading/backtest_engine.h
+++ b/hftengine/core/trading/backtest_engine.h
@@ -50,12 +50,18 @@ class BacktestEngine {
     Depth depth(int asset_id);
     Timestamp current_time();
 
+    void set_order_entry_latency(const Microseconds latency_us);
+    void set_order_response_latency(const Microseconds latency_us);
+    void set_market_feed_latency(const Microseconds latency_us);
+
     const Microseconds order_entry_latency() const;
     const Microseconds order_response_latency() const;
+    const Microseconds market_feed_latency() const;
 
   private:
     Microseconds order_entry_latency_us = 1000;
     Microseconds order_response_latency_us = 1000;
+    Microseconds market_feed_latency_us = 50000;
 
     // exchange origin methods
     bool clear_inactive_orders(int asset_id);

--- a/tests/test_backtest_engine.cpp
+++ b/tests/test_backtest_engine.cpp
@@ -156,6 +156,8 @@ TEST_CASE("[BacktestEngine] - elapse", "[backtest-engine][elapse]") {
     }
     SECTION("Market order executed in correct schedule") {
         BacktestEngine hbt(asset_configs);
+        hbt.set_order_entry_latency(1000);
+        hbt.set_order_response_latency(1000);
         REQUIRE(hbt.elapse(29500));
         REQUIRE(hbt.current_time() == 29500);
 


### PR DESCRIPTION
Order entry and response latency can be manually set in the backtestengine. 