### PR TITLE
logger optional for backtest

### DIFF
--- a/hftengine/backtest_main.cpp
+++ b/hftengine/backtest_main.cpp
@@ -27,16 +27,17 @@ int main() {
     std::unordered_map<int, AssetConfig> asset_configs;
     const int asset_id = 1; // Example asset ID
     asset_configs.insert({asset_id, asset_config});
-    auto logger = std::make_shared<Logger>("backtest.log", LogLevel::Error);
+    //auto logger = std::make_shared<Logger>("backtest.log", LogLevel::Error);
+    auto logger = nullptr;
 
     BacktestEngine hbt(asset_configs, logger);
-    Recorder recorder(5'000'000, logger); 
+    Recorder recorder(1'000'000, logger); 
     GridTrading grid_trading(1, grid_trading_config, logger);
     
     auto start = std::chrono::high_resolution_clock::now();
 
     std::uint64_t iter = 7200;
-    while (hbt.elapse(500'000) && iter-- > 0) {
+    while (hbt.elapse(10'000'000) && iter-- > 0) {
         hbt.clear_inactive_orders();
         grid_trading.on_elapse(hbt);
         recorder.record(hbt, asset_id); 
@@ -45,6 +46,11 @@ int main() {
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = end - start;
     std::cout << "Backtest wall time: " << elapsed.count() << " seconds\n";
+
+    std::cout << "Final equity: " << hbt.equity() << "\n";
+    std::cout << "Sharpe Ratio: " << recorder.sharpe() << "\n";
+    std::cout << "Sortino Ratio: " << recorder.sortino() << "\n";
+    std::cout << "Max Drawdown: " << recorder.max_drawdown() << "\n";
 
     recorder.plot(asset_id); 
 

--- a/hftengine/core/execution_engine/execution_engine.cpp
+++ b/hftengine/core/execution_engine/execution_engine.cpp
@@ -224,15 +224,18 @@ void ExecutionEngine::execute_market_order(int asset_id, TradeSide side,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::FILL,
                             .order_ = *order});
-            logger_->log(
-                "[ExecutionEngine] - " +
-                    std::to_string(order->exch_timestamp_) + "us - Market " +
-                    ((side == TradeSide::Buy) ? "buy" : "sell") +
-                    " order fully filled : id=" +
-                    std::to_string(order->orderId_) +
-                    ", price=" + std::to_string(level_price) + ", qty=" +
-                    std::to_string(order->quantity_ - order->filled_quantity_),
-                LogLevel::Debug);
+            if (logger_) {
+                logger_->log("[ExecutionEngine] - " +
+                                 std::to_string(order->exch_timestamp_) +
+                                 "us - Market " +
+                                 ((side == TradeSide::Buy) ? "buy" : "sell") +
+                                 " order fully filled : id=" +
+                                 std::to_string(order->orderId_) + ", price=" +
+                                 std::to_string(level_price) + ", qty=" +
+                                 std::to_string(order->quantity_ -
+                                                order->filled_quantity_),
+                             LogLevel::Debug);
+            }
         } else {
             fills_.emplace_back(
                 Fill{.asset_id_ = asset_id,
@@ -307,11 +310,14 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
     }
     if (available_qty < order->quantity_) {
         order->orderStatus_ = OrderStatus::REJECTED;
-        logger_->log("[ExecutionEngine] - " +
-                         std::to_string(order->exch_timestamp_) + "us - FOK " +
-                         ((side == TradeSide::Buy) ? "buy" : "sell") +
-                         " order rejected, insufficient liquidity",
-                     LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[ExecutionEngine] - " +
+                             std::to_string(order->exch_timestamp_) +
+                             "us - FOK " +
+                             ((side == TradeSide::Buy) ? "buy" : "sell") +
+                             " order rejected, insufficient liquidity",
+                         LogLevel::Debug);
+        }
         return false;
     }
     level = -1;
@@ -369,13 +375,17 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
                             .order_ = *order});
         }
         order->orderStatus_ = OrderStatus::FILLED;
-        logger_->log(
-            "[ExecutionEngine] - " + std::to_string(order->exch_timestamp_) +
-                "us - FOK " + ((side == TradeSide::Buy) ? "buy" : "sell") +
-                " order fully filled : id=" + std::to_string(order->orderId_) +
-                ", price=" + std::to_string(order->price_) +
-                ", qty=" + std::to_string(order->filled_quantity_),
-            LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[ExecutionEngine] - " +
+                             std::to_string(order->exch_timestamp_) +
+                             "us - FOK " +
+                             ((side == TradeSide::Buy) ? "buy" : "sell") +
+                             " order fully filled : id=" +
+                             std::to_string(order->orderId_) +
+                             ", price=" + std::to_string(order->price_) +
+                             ", qty=" + std::to_string(order->filled_quantity_),
+                         LogLevel::Debug);
+        }
     }
     return true;
 }
@@ -408,11 +418,14 @@ bool ExecutionEngine::execute_fok_order(int asset_id, TradeSide side,
 bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
                                         std::shared_ptr<Order> order) {
     if (order->orderStatus_ != OrderStatus::NEW) {
-        logger_->log("[ExecutionEngine] - " +
-                         std::to_string(order->exch_timestamp_) + " - IOC " +
-                         ((side == TradeSide::Buy) ? "buy" : "sell") +
-                         " order not NEW, skipping",
-                     LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[ExecutionEngine] - " +
+                             std::to_string(order->exch_timestamp_) +
+                             " - IOC " +
+                             ((side == TradeSide::Buy) ? "buy" : "sell") +
+                             " order not NEW, skipping",
+                         LogLevel::Debug);
+        }
         return false;
     }
     int level = 0;
@@ -453,15 +466,17 @@ bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::FILL,
                             .order_ = *order});
-            logger_->log("[ExecutionEngine] - " +
-                             std::to_string(order->exch_timestamp_) +
-                             "us - IOC " +
-                             ((side == TradeSide::Buy) ? "buy" : "sell") +
-                             " order fully filled : id=" +
-                             std::to_string(order->orderId_) +
-                             ", price=" + std::to_string(order->price_) +
-                             ", qty=" + std::to_string(order->filled_quantity_),
-                         LogLevel::Debug);
+            if (logger_) {
+                logger_->log(
+                    "[ExecutionEngine] - " +
+                        std::to_string(order->exch_timestamp_) + "us - IOC " +
+                        ((side == TradeSide::Buy) ? "buy" : "sell") +
+                        " order fully filled : id=" +
+                        std::to_string(order->orderId_) +
+                        ", price=" + std::to_string(order->price_) +
+                        ", qty=" + std::to_string(order->filled_quantity_),
+                    LogLevel::Debug);
+            }
         } else {
             order->filled_quantity_ += level_depth;
             order->orderStatus_ = OrderStatus::PARTIALLY_FILLED;
@@ -483,15 +498,17 @@ bool ExecutionEngine::execute_ioc_order(int asset_id, TradeSide side,
                             .orderId_ = order->orderId_,
                             .event_type_ = OrderEventType::FILL,
                             .order_ = *order});
-            logger_->log("[ExecutionEngine] - " +
-                             std::to_string(order->exch_timestamp_) +
-                             "us - IOC " +
-                             ((side == TradeSide::Buy) ? "buy" : "sell") +
-                             " order partially filled: id=" +
-                             std::to_string(order->orderId_) +
-                             ", price=" + std::to_string(order->price_) +
-                             ", qty=" + std::to_string(order->filled_quantity_),
-                         LogLevel::Debug);
+            if (logger_) {
+                logger_->log(
+                    "[ExecutionEngine] - " +
+                        std::to_string(order->exch_timestamp_) + "us - IOC " +
+                        ((side == TradeSide::Buy) ? "buy" : "sell") +
+                        " order partially filled: id=" +
+                        std::to_string(order->orderId_) +
+                        ", price=" + std::to_string(order->price_) +
+                        ", qty=" + std::to_string(order->filled_quantity_),
+                    LogLevel::Debug);
+            }
         }
         level++;
     }
@@ -537,11 +554,14 @@ bool ExecutionEngine::place_maker_order(int asset_id,
         (order->side_ == BookSide::Ask && best_bid > 0.0 &&
          order->price_ <= best_bid)) {
         order->orderStatus_ = OrderStatus::REJECTED;
-        logger_->log("[ExecutionEngine] - " +
-                         std::to_string(order->exch_timestamp_) + " - maker " +
-                         ((order->side_ == BookSide::Bid) ? "BID" : "ASK") +
-                         " order rejected",
-                     LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[ExecutionEngine] - " +
+                             std::to_string(order->exch_timestamp_) +
+                             " - maker " +
+                             ((order->side_ == BookSide::Bid) ? "BID" : "ASK") +
+                             " order rejected",
+                         LogLevel::Debug);
+        }
         return false;
     }
     Ticks order_price_ticks =
@@ -555,13 +575,16 @@ bool ExecutionEngine::place_maker_order(int asset_id,
     orders_[order->orderId_] = order;
     active_orders_[asset_id].push_back(order);
     order->orderStatus_ = OrderStatus::ACTIVE;
-    logger_->log("[ExecutionEngine] - " +
-                     std::to_string(order->exch_timestamp_) + "us - maker " +
-                     ((order->side_ == BookSide::Bid) ? "BID" : "ASK") +
-                     " order placed : id=" + std::to_string(order->orderId_) +
-                     ", price=" + std::to_string(order->price_) +
-                     ", qty=" + std::to_string(order->quantity_),
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log(
+            "[ExecutionEngine] - " + std::to_string(order->exch_timestamp_) +
+                "us - maker " +
+                ((order->side_ == BookSide::Bid) ? "BID" : "ASK") +
+                " order placed : id=" + std::to_string(order->orderId_) +
+                ", price=" + std::to_string(order->price_) +
+                ", qty=" + std::to_string(order->quantity_),
+            LogLevel::Debug);
+    }
     order_updates_.emplace_back(OrderUpdate{
         .exch_timestamp_ = order->exch_timestamp_,
         .local_timestamp_ = order->exch_timestamp_ + order_response_latency_us_,
@@ -588,17 +611,21 @@ bool ExecutionEngine::place_maker_order(int asset_id,
  */
 bool ExecutionEngine::execute_order(int asset_id, TradeSide side,
                                     const Order &order) {
-    logger_->log("[ExecutionEngine] - " +
-                     std::to_string(order.exch_timestamp_) + "us - " +
-                     ((side == TradeSide::Buy) ? "BUY" : "SELL") +
-                     " order received: id=" + std::to_string(order.orderId_) +
-                     ", price=" + std::to_string(order.price_) +
-                     ", qty=" + std::to_string(order.quantity_),
-                 LogLevel::Debug);
-    logger_->log("[ExecutionEngine] - " +
-                     std::to_string(order.exch_timestamp_) +
-                     "us - total orders=" + std::to_string(orders_.size()),
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log(
+            "[ExecutionEngine] - " + std::to_string(order.exch_timestamp_) +
+                "us - " + ((side == TradeSide::Buy) ? "BUY" : "SELL") +
+                " order received: id=" + std::to_string(order.orderId_) +
+                ", price=" + std::to_string(order.price_) +
+                ", qty=" + std::to_string(order.quantity_),
+            LogLevel::Debug);
+    }
+    if (logger_) {
+        logger_->log("[ExecutionEngine] - " +
+                         std::to_string(order.exch_timestamp_) +
+                         "us - total orders=" + std::to_string(orders_.size()),
+                     LogLevel::Debug);
+    }
     auto order_ptr = std::make_shared<Order>(order);
     if (order.orderType_ == OrderType::MARKET) {
         execute_market_order(asset_id, side, order_ptr);
@@ -723,62 +750,79 @@ void ExecutionEngine::handle_trade(int asset_id, const Trade &trade) {
                    : maker_books_[asset_id].ask_orders_.end();
     if (it == end) {
         if (trade.side_ == TradeSide::Sell) {
-            logger_->log(
-                "[ExecutionEngine] - " + std::to_string(trade.exch_timestamp_) +
-                    "us - no matching orders found at price " +
-                    std::to_string(trade.price_) + " among " +
-                    std::to_string(maker_books_[asset_id].bid_orders_.size()) +
-                    " bid orders",
-                LogLevel::Debug);
-            /*for (const auto &kv : maker_books_[asset_id].bid_orders_) {
-                logger_->log(std::to_string(ticks_to_price(
-                                        kv.first, tick_sizes_[asset_id])));
-            }*/
+            if (logger_) {
+                logger_->log(
+                    "[ExecutionEngine] - " +
+                        std::to_string(trade.exch_timestamp_) +
+                        "us - no matching orders found at price " +
+                        std::to_string(trade.price_) + " among " +
+                        std::to_string(
+                            maker_books_[asset_id].bid_orders_.size()) +
+                        " bid orders",
+                    LogLevel::Debug);
+                for (const auto &kv : maker_books_[asset_id].bid_orders_) {
+                    logger_->log(std::to_string(ticks_to_price(
+                                     kv.first, tick_sizes_[asset_id])),
+                                 LogLevel::Debug);
+                }
+            }
         } else if (trade.side_ == TradeSide::Buy) {
-            logger_->log(
-                "[ExecutionEngine] - " + std::to_string(trade.exch_timestamp_) +
-                    "us - no matching orders found at price " +
-                    std::to_string(trade.price_) + " among " +
-                    std::to_string(maker_books_[asset_id].ask_orders_.size()) +
-                    " ask orders",
-                LogLevel::Debug);
-            /*for (const auto &kv : maker_books_[asset_id].ask_orders_) {
-                logger_->log("\n" + std::to_string(ticks_to_price(
-                                        kv.first, tick_sizes_[asset_id])));
-            } */
+            if (logger_) {
+                logger_->log(
+                    "[ExecutionEngine] - " +
+                        std::to_string(trade.exch_timestamp_) +
+                        "us - no matching orders found at price " +
+                        std::to_string(trade.price_) + " among " +
+                        std::to_string(
+                            maker_books_[asset_id].ask_orders_.size()) +
+                        " ask orders",
+                    LogLevel::Debug);
+                for (const auto &kv : maker_books_[asset_id].ask_orders_) {
+                    logger_->log(std::to_string(ticks_to_price(
+                                     kv.first, tick_sizes_[asset_id])),
+                                 LogLevel::Debug);
+                }
+            }
         }
         return;
     }
     auto order = it->second;
 
     if (order->exch_timestamp_ >= trade.exch_timestamp_) return;
-    logger_->log("[ExecutionEngine] - " +
-                     std::to_string(trade.exch_timestamp_) + "us - order (" +
-                     std::to_string(order->orderId_) +
-                     ") found at trade price " + std::to_string(order->price_),
-                 LogLevel::Debug);
-
+    if (logger_) {
+        logger_->log(
+            "[ExecutionEngine] - " + std::to_string(trade.exch_timestamp_) +
+                "us - order (" + std::to_string(order->orderId_) +
+                ") found at trade price " + std::to_string(order->price_),
+            LogLevel::Debug);
+    }
     if (order->queueEst_ == 0.0 && order->filled_quantity_ < order->quantity_) {
         Quantity fill_qty = std::min(
             trade.quantity_, order->quantity_ - order->filled_quantity_);
         order->filled_quantity_ += fill_qty;
         if (order->filled_quantity_ >= order->quantity_) {
             order->orderStatus_ = OrderStatus::FILLED;
-            logger_->log(
-                "[ExecutionEngine] - " + std::to_string(trade.exch_timestamp_) +
-                    "us - order (" + std::to_string(order->orderId_) +
-                    ") filled at price=" + std::to_string(order->price_) +
-                    ", qty=" + std::to_string(order->filled_quantity_),
-                LogLevel::Debug);
+            if (logger_) {
+                logger_->log(
+                    "[ExecutionEngine] - " +
+                        std::to_string(trade.exch_timestamp_) + "us - order (" +
+                        std::to_string(order->orderId_) +
+                        ") filled at price=" + std::to_string(order->price_) +
+                        ", qty=" + std::to_string(order->filled_quantity_),
+                    LogLevel::Debug);
+            }
         } else {
             order->orderStatus_ = OrderStatus::PARTIALLY_FILLED;
-            logger_->log("[ExecutionEngine] - " +
-                             std::to_string(trade.exch_timestamp_) +
-                             "us - order (" + std::to_string(order->orderId_) +
-                             ") partially filled at price=" +
-                             std::to_string(order->price_) +
-                             ", qty=" + std::to_string(order->filled_quantity_),
-                         LogLevel::Debug);
+            if (logger_) {
+                logger_->log(
+                    "[ExecutionEngine] - " +
+                        std::to_string(trade.exch_timestamp_) + "us - order (" +
+                        std::to_string(order->orderId_) +
+                        ") partially filled at price=" +
+                        std::to_string(order->price_) +
+                        ", qty=" + std::to_string(order->filled_quantity_),
+                    LogLevel::Debug);
+            }
         }
         order_updates_.emplace_back(
             OrderUpdate{.exch_timestamp_ = trade.exch_timestamp_,

--- a/hftengine/core/recorder/recorder.cpp
+++ b/hftengine/core/recorder/recorder.cpp
@@ -35,9 +35,11 @@
  */
 Recorder::Recorder(Microseconds interval_us, std::shared_ptr<Logger> logger)
     : interval_us_(interval_us), logger_(logger) {
-    logger_->log("[Recorder] - Initialized with interval: " +
-                     std::to_string(interval_us) + " microseconds"
-                 , LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[Recorder] - Initialized with interval: " +
+                         std::to_string(interval_us) + " microseconds",
+                     LogLevel::Debug);
+    }
 }
 
 /**
@@ -86,13 +88,15 @@ void Recorder::record(const BacktestEngine &hbt, int asset_id) {
     records_.emplace_back(EquitySnapshot{current_time, equity});
     state_records_.emplace_back(
         StateSnapshot{current_time, equity, position, mid_price});
-
-    logger_->log("[Recorder] - " + std::to_string(current_time) +
-                 "us - asset_id= " + std::to_string(asset_id) +
-                 ", equity=" + std::to_string(equity) +
-                 ", position=" + std::to_string(position) +
-                     ", price=" + std::to_string(mid_price),
-                 LogLevel::Debug);
+    
+    if (logger_) {
+        logger_->log("[Recorder] - " + std::to_string(current_time) +
+                         "us - asset_id= " + std::to_string(asset_id) +
+                         ", equity=" + std::to_string(equity) +
+                         ", position=" + std::to_string(position) +
+                         ", price=" + std::to_string(mid_price),
+                     LogLevel::Debug);
+    }
 }
 
 /**

--- a/hftengine/core/strategy/grid_trading.cpp
+++ b/hftengine/core/strategy/grid_trading.cpp
@@ -46,9 +46,11 @@ GridTrading::GridTrading(int asset_id, const GridTradingConfig &config,
 }
 
 void GridTrading::initialize() {
-    logger_->log("[GridTrading] - Strategy initialized for asset ID: " +
-                     std::to_string(asset_id_),
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[GridTrading] - Strategy initialized for asset ID: " +
+                         std::to_string(asset_id_),
+                     LogLevel::Debug);
+    }
 }
 
 void GridTrading::on_elapse(BacktestEngine &hbt) {
@@ -126,18 +128,20 @@ void GridTrading::on_elapse(BacktestEngine &hbt) {
                  new_ask_prices.find(order_price_ticks) ==
                      new_ask_prices.end())) {
                 hbt.cancel_order(asset_id_, order.orderId_);
-                if (order.side_ == BookSide::Bid) {
-                    logger_->log(
-                        "[GridTrading] - Cancelled bid order at price: " +
-                            std::to_string(order.price_) +
-                            " for asset ID: " + std::to_string(asset_id_),
-                        LogLevel::Debug);
-                } else {
-                    logger_->log(
-                        "[GridTrading] - Cancelled ask order at price: " +
-                            std::to_string(order.price_) +
-                            " for asset ID: " + std::to_string(asset_id_),
-                        LogLevel::Debug);
+                if (logger_) {
+                    if (order.side_ == BookSide::Bid) {
+                        logger_->log(
+                            "[GridTrading] - Cancelled bid order at price: " +
+                                std::to_string(order.price_) +
+                                " for asset ID: " + std::to_string(asset_id_),
+                            LogLevel::Debug);
+                    } else {
+                        logger_->log(
+                            "[GridTrading] - Cancelled ask order at price: " +
+                                std::to_string(order.price_) +
+                                " for asset ID: " + std::to_string(asset_id_),
+                            LogLevel::Debug);
+                    }
                 }
             }
         }
@@ -150,26 +154,34 @@ void GridTrading::on_elapse(BacktestEngine &hbt) {
             existing_bid_prices.end()) {
             Price bid_price = bid_price_ticks * tick_size;
             if (bid_price_ticks <= 0) {
-                logger_->log("[GridTrading] - Invalid bid price: " +
-                                 std::to_string(bid_price) +
-                                 " for asset ID: " + std::to_string(asset_id_) +
-                                 ". Skipping order submission.",
-                             LogLevel::Info);
+                if (logger_) {
+                    logger_->log(
+                        "[GridTrading] - Invalid bid price: " +
+                            std::to_string(bid_price) +
+                            " for asset ID: " + std::to_string(asset_id_) +
+                            ". Skipping order submission.",
+                        LogLevel::Info);
+                }
                 continue;
             }
             if (order_qty <= 0.0) {
-                logger_->log("[GridTrading] - Invalid bid order quantity: " +
-                                 std::to_string(order_qty) +
-                                 " for asset ID: " + std::to_string(asset_id_) +
-                                 ". Skipping order submission.",
-                             LogLevel::Info);
+                if (logger_) {
+                    logger_->log(
+                        "[GridTrading] - Invalid bid order quantity: " +
+                            std::to_string(order_qty) +
+                            " for asset ID: " + std::to_string(asset_id_) +
+                            ". Skipping order submission.",
+                        LogLevel::Info);
+                }
                 continue;
             }
-            logger_->log("[GridTrading] - Submitted buy order : asset_id=" +
-                             std::to_string(asset_id_) +
-                             ", price=" + std::to_string(bid_price) +
-                             ", qty=" + std::to_string(order_qty),
-                         LogLevel::Info);
+            if (logger_) {
+                logger_->log("[GridTrading] - Submitted buy order : asset_id=" +
+                                 std::to_string(asset_id_) +
+                                 ", price=" + std::to_string(bid_price) +
+                                 ", qty=" + std::to_string(order_qty),
+                             LogLevel::Info);
+            }
             hbt.submit_buy_order(asset_id_, bid_price, order_qty,
                                  TimeInForce::GTC, OrderType::LIMIT);
         }
@@ -179,28 +191,36 @@ void GridTrading::on_elapse(BacktestEngine &hbt) {
             existing_ask_prices.end()) {
             Price ask_price = ask_price_ticks * tick_size;
             if (ask_price <= 0.0) {
-                logger_->log("[GridTrading] - Invalid ask price: " +
-                                 std::to_string(bid_price) +
-                                 " for asset ID: " + std::to_string(asset_id_) +
-                                 ". Skipping order submission.",
-                             LogLevel::Info);
+                if (logger_) {
+                    logger_->log(
+                        "[GridTrading] - Invalid ask price: " +
+                            std::to_string(bid_price) +
+                            " for asset ID: " + std::to_string(asset_id_) +
+                            ". Skipping order submission.",
+                        LogLevel::Info);
+                }
                 continue;
             }
             if (order_qty <= 0.0) {
-                logger_->log("[GridTrading] - Invalid ask order quantity: " +
-                                 std::to_string(order_qty) +
-                                 " for asset ID: " + std::to_string(asset_id_) +
-                                 ". Skipping order submission.",
-                             LogLevel::Info);
+                if (logger_) {
+                    logger_->log(
+                        "[GridTrading] - Invalid ask order quantity: " +
+                            std::to_string(order_qty) +
+                            " for asset ID: " + std::to_string(asset_id_) +
+                            ". Skipping order submission.",
+                        LogLevel::Info);
+                }
                 continue;
             }
             hbt.submit_sell_order(asset_id_, ask_price, order_qty,
                                   TimeInForce::GTC, OrderType::LIMIT);
-            logger_->log("[GridTrading] - Submitted buy order : asset_id=" +
-                             std::to_string(asset_id_) +
-                             ", price=" + std::to_string(bid_price) +
-                             ", qty=" + std::to_string(order_qty),
-                         LogLevel::Info);
+            if (logger_) {
+                logger_->log("[GridTrading] - Submitted buy order : asset_id=" +
+                                 std::to_string(asset_id_) +
+                                 ", price=" + std::to_string(bid_price) +
+                                 ", qty=" + std::to_string(order_qty),
+                             LogLevel::Info);
+            }
         }
     }
 }

--- a/hftengine/core/trading/backtest_engine.cpp
+++ b/hftengine/core/trading/backtest_engine.cpp
@@ -78,11 +78,12 @@ BacktestEngine::BacktestEngine(
     } else {
         current_time_us_ = 0;
     }
-
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - Initialized with " + std::to_string(assets_.size()) +
-                     " assets.",
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - Initialized with " +
+                         std::to_string(assets_.size()) + " assets.",
+                     LogLevel::Debug);
+    }
 }
 
 /**
@@ -183,9 +184,11 @@ bool BacktestEngine::elapse(std::uint64_t microseconds) {
         }
     }
     current_time_us_ = next_interval_us;
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - elapse complete",
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - elapse complete",
+                     LogLevel::Debug);
+    }
     return std::isfinite(current_time_us_);
 }
 
@@ -203,9 +206,11 @@ bool BacktestEngine::order_inactive(const Order &order) {
  * @param asset_id
  */
 void BacktestEngine::clear_inactive_orders() {
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - clearing inactive orders",
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - clearing inactive orders",
+                     LogLevel::Debug);
+    }
     for (auto &asset_pair : assets_) {
         int asset_id = asset_pair.first;
         execution_engine_.clear_inactive_orders(asset_id);
@@ -213,11 +218,13 @@ void BacktestEngine::clear_inactive_orders() {
     for (auto it = local_active_orders_.begin();
          it != local_active_orders_.end();) {
         if (order_inactive(it->second)) {
-            logger_->log("[BacktestEngine] - " +
-                             std::to_string(current_time_us_) +
-                             "us - clearing inactive order (" +
-                             std::to_string(it->second.orderId_) + ")",
-                         LogLevel::Debug);
+            if (logger_) {
+                logger_->log("[BacktestEngine] - " +
+                                 std::to_string(current_time_us_) +
+                                 "us - clearing inactive order (" +
+                                 std::to_string(it->second.orderId_) + ")",
+                             LogLevel::Debug);
+            }
             it = local_active_orders_.erase(it);
         } else {
             ++it;
@@ -257,10 +264,13 @@ OrderId BacktestEngine::submit_buy_order(int asset_id, Price price,
                     .orderType_ = orderType,
                     .queueEst_ = 0.0,
                     .orderStatus_ = OrderStatus::NEW};
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - buy order (" + std::to_string(buy_order.orderId_) +
-                     ") submitted to exchange",
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - buy order (" +
+                         std::to_string(buy_order.orderId_) +
+                         ") submitted to exchange",
+                     LogLevel::Debug);
+    }
     delayed_actions_.insert(
         {buy_order.exch_timestamp_,
          DelayedAction{.type_ = ActionType::SubmitBuy,
@@ -302,10 +312,13 @@ OrderId BacktestEngine::submit_sell_order(int asset_id, Price price,
                      .orderType_ = orderType,
                      .queueEst_ = 0.0,
                      .orderStatus_ = OrderStatus::NEW};
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - sell order (" + std::to_string(sell_order.orderId_) +
-                     ") submitted to exchange"
-                 , LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - sell order (" +
+                         std::to_string(sell_order.orderId_) +
+                         ") submitted to exchange",
+                     LogLevel::Debug);
+    }
     delayed_actions_.insert(
         {sell_order.exch_timestamp_,
          DelayedAction{.type_ = ActionType::SubmitSell,
@@ -363,28 +376,40 @@ void BacktestEngine::process_order_update_local(OrderEventType event_type,
                                                 OrderId orderId, Order order) {
     if (event_type == OrderEventType::ACKNOWLEDGED) {
         local_active_orders_[orderId] = order;
-        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                         "us - ACKNOWLEDGE recieved locally (" +
-                         std::to_string(orderId) + ") update"
-                     , LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[BacktestEngine] - " +
+                             std::to_string(current_time_us_) +
+                             "us - ACKNOWLEDGE recieved locally (" +
+                             std::to_string(orderId) + ") update",
+                         LogLevel::Debug);
+        }
     } else if (event_type == OrderEventType::CANCELLED) {
         auto it = local_active_orders_.find(orderId);
         if (it != local_active_orders_.end()) local_active_orders_.erase(it);
-        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                         "us - CANCELLED recieved locally (" +
-                         std::to_string(orderId) + ") update" 
-                     , LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[BacktestEngine] - " +
+                             std::to_string(current_time_us_) +
+                             "us - CANCELLED recieved locally (" +
+                             std::to_string(orderId) + ") update",
+                         LogLevel::Debug);
+        }
     } else if (event_type == OrderEventType::FILL) {
         local_active_orders_[orderId] = order;
-        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                         "us - FILL recieved locally (" +
-                         std::to_string(orderId) + ") update"
-                     , LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[BacktestEngine] - " +
+                             std::to_string(current_time_us_) +
+                             "us - FILL recieved locally (" +
+                             std::to_string(orderId) + ") update",
+                         LogLevel::Debug);
+        }
     } else if (event_type == OrderEventType::REJECTED) {
-        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                         "us - REJECTED recieved locally (" +
-                         std::to_string(orderId) + ") update"
-                     , LogLevel::Debug);
+        if (logger_) {
+            logger_->log("[BacktestEngine] - " +
+                             std::to_string(current_time_us_) +
+                             "us - REJECTED recieved locally (" +
+                             std::to_string(orderId) + ") update",
+                         LogLevel::Debug);
+        }
     } else {
         throw std::invalid_argument(
             "Unknown OrderEventType in local order update");
@@ -440,12 +465,14 @@ void BacktestEngine::process_exchange_fills() {
  *       additional logic may be needed.
  */
 void BacktestEngine::process_fill_local(int asset_id, const Fill &fill) {
-    // update output to include fill price and quantity
-    logger_->log("[BacktestEngine] - " + std::to_string(fill.local_timestamp_) +
-                     "us - fill processed locally, price=" +
-                     std::to_string(fill.price_) +
-                     ", qty=" + std::to_string(fill.quantity_),
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " +
+                         std::to_string(fill.local_timestamp_) +
+                         "us - fill processed locally, price=" +
+                         std::to_string(fill.price_) +
+                         ", qty=" + std::to_string(fill.quantity_),
+                     LogLevel::Debug);
+    }
     Quantity signed_qty =
         (fill.side_ == TradeSide::Buy) ? fill.quantity_ : -fill.quantity_;
     local_position_[asset_id] += signed_qty;
@@ -473,11 +500,13 @@ void BacktestEngine::process_book_update_local(int asset_id,
  * @return A vector containing all active orders for the specified asset.
  */
 const std::vector<Order> BacktestEngine::orders(int asset_id) const {
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - retrieving " +
-                     std::to_string(local_active_orders_.size()) +
-                     " local active orders",
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - retrieving " +
+                         std::to_string(local_active_orders_.size()) +
+                         " local active orders",
+                     LogLevel::Debug);
+    }
     std::vector<Order> active_orders;
     active_orders.reserve(local_active_orders_.size());
     for (const auto &[id, order] : local_active_orders_) {
@@ -536,10 +565,12 @@ const Depth BacktestEngine::depth(int asset_id) const {
         local_orderbooks_.at(asset_id).depth_at_level(BookSide::Ask, 0);
     Quantity bid_0_size =
         local_orderbooks_.at(asset_id).depth_at_level(BookSide::Bid, 0);
-    logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
-                     "us - retrieving depth for asset " +
-                     std::to_string(asset_id),
-                 LogLevel::Debug);
+    if (logger_) {
+        logger_->log("[BacktestEngine] - " + std::to_string(current_time_us_) +
+                         "us - retrieving depth for asset " +
+                         std::to_string(asset_id),
+                     LogLevel::Debug);
+    }
     // local_orderbooks_.at(asset_id).print_top_levels();
     std::unordered_map<Ticks, Quantity> bid_depth;
     int bid_levels = local_orderbooks_.at(asset_id).bid_levels();


### PR DESCRIPTION
`Logger` can now be a `nullptr` in the backtest loop to save compute time.