### PR TITLE
print strategy statistics

### DIFF
--- a/config/grid_trading_config.txt
+++ b/config/grid_trading_config.txt
@@ -1,7 +1,7 @@
 tick_size=0.01
 lot_size=0.1
-grid_num=3
-grid_interval=10
-half_spread=20
-position_limit=300.0
+grid_num=10
+grid_interval=5
+half_spread=2
+position_limit=1000.0
 notional_order_qty=100.0

--- a/hftengine/core/execution_engine/execution_engine.h
+++ b/hftengine/core/execution_engine/execution_engine.h
@@ -57,14 +57,14 @@ class ExecutionEngine {
     void clear_fills();
     void clear_order_updates();
 
-    double f(const double x);
+    constexpr double f(const double x);
 
     void set_order_entry_latency_us(const Microseconds latency_us);
     void set_order_response_latency_us(const Microseconds latency_us);
 
   private:
-    std::uint64_t order_entry_latency_us_ = 1000;
-    std::uint64_t order_response_latency_us_ = 1000;
+    Microseconds order_entry_latency_us_ = 25000;
+    Microseconds order_response_latency_us_ = 10000;
 
     std::unordered_map<int, double> tick_sizes_;
     std::unordered_map<int, double> lot_sizes_;
@@ -75,8 +75,8 @@ class ExecutionEngine {
     std::vector<Fill> fills_;
 
     struct MakerBook {
-        std::map<Ticks, std::shared_ptr<Order>, std::greater<>> bid_orders_;
-        std::map<Ticks, std::shared_ptr<Order>> ask_orders_;
+        std::unordered_map<Ticks, std::shared_ptr<Order>> bid_orders_;
+        std::unordered_map<Ticks, std::shared_ptr<Order>> ask_orders_;
     };
     std::unordered_map<int, MakerBook> maker_books_;
 

--- a/hftengine/core/recorder/recorder.cpp
+++ b/hftengine/core/recorder/recorder.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -232,6 +233,45 @@ double Recorder::max_drawdown() const {
     return max_dd;
 }
 
+/**
+ * @brief Prints the performance metrics of the recorded equities.
+ *
+ * This method outputs the Sharpe ratio, Sortino ratio, and maximum drawdown
+ * to the console, formatted to four decimal places for ratios and two decimal
+ * places for drawdown percentage.
+ */
+void Recorder::print_performance_metrics() const {
+    std::cout << "=== Performance Metrics ===\n";
+    try {
+        std::cout << "Sharpe Ratio   : " << std::fixed << std::setprecision(4)
+                  << sharpe() << "\n";
+    } catch (const std::exception &e) {
+        std::cout << "Sharpe Ratio   : Error (" << e.what() << ")\n";
+    }
+    try {
+        std::cout << "Sortino Ratio  : " << std::fixed << std::setprecision(4)
+                  << sortino() << "\n";
+    } catch (const std::exception &e) {
+        std::cout << "Sortino Ratio  : Error (" << e.what() << ")\n";
+    }
+    try {
+        std::cout << "Max Drawdown   : " << std::fixed << std::setprecision(2)
+                  << 100 * max_drawdown() << "%\n";
+    } catch (const std::exception &e) {
+        std::cout << "Max Drawdown   : Error (" << e.what() << ")\n";
+    }
+    std::cout << "==========================\n";
+}
+
+/**
+ * @brief Plots the recorded equity and position for a specific asset.
+ *
+ * This method generates a CSV file containing the equity, position, and mid
+ * price for the specified asset ID, and then calls an external Python script
+ * to plot the data.
+ *
+ * @param asset_id The ID of the asset to plot.
+ */
 void Recorder::plot(int asset_id) const {
     std::string csv_filename =
         "recorder_plot_" + std::to_string(asset_id) + ".csv";

--- a/hftengine/core/recorder/recorder.h
+++ b/hftengine/core/recorder/recorder.h
@@ -31,6 +31,7 @@ class Recorder {
     double sortino() const;
     double max_drawdown() const;
 
+    void print_performance_metrics() const;
     void plot(int asset_id) const;
 
     std::vector<double> interval_returns() const;

--- a/hftengine/core/trading/backtest_engine.h
+++ b/hftengine/core/trading/backtest_engine.h
@@ -33,7 +33,7 @@ class BacktestEngine {
   public:
     explicit BacktestEngine(
         const std::unordered_map<int, AssetConfig> &asset_configs,
-        std::shared_ptr<Logger> logger = nullptr);
+        std::shared_ptr<Logger> logger = nullptr, double cash=0.0);
 
     // global methods
     bool elapse(std::uint64_t microseconds);
@@ -56,6 +56,10 @@ class BacktestEngine {
     const Depth depth(int asset_id) const;
     const Timestamp current_time() const;
 
+    void print_trading_stats(int asset_id) const;
+
+    void set_cash(double cash);
+
     void set_order_entry_latency(Microseconds latency_us);
     void set_order_response_latency(Microseconds latency_us);
     void set_market_feed_latency(Microseconds latency_us);
@@ -65,8 +69,8 @@ class BacktestEngine {
     const Microseconds market_feed_latency() const;
 
   private:
-    Microseconds order_entry_latency_us = 50000;
-    Microseconds order_response_latency_us = 50000;
+    Microseconds order_entry_latency_us = 25000;
+    Microseconds order_response_latency_us = 10000;
     Microseconds market_feed_latency_us = 50000;
 
     // backtest simulation methods
@@ -78,25 +82,27 @@ class BacktestEngine {
     void process_fill_local(int asset_id, const Fill &fill);
     void process_book_update_local(int asset_id, const BookUpdate &book_update);
 
-    Timestamp current_time_us_; // microseconds
+    Timestamp current_time_us_; 
     ExecutionEngine execution_engine_;
     MarketDataFeed market_data_feed_;
     OrderIdGenerator orderId_gen_;
     
-    std::unordered_map<int, OrderBook> local_orderbooks_;
-    std::unordered_map<int, Order> local_active_orders_;
+    // asset configurations
     std::unordered_map<int, BacktestAsset> assets_;
-
     std::unordered_map<int, double> tick_sizes_;
     std::unordered_map<int, double> lot_sizes_;
+    
+    // local state (updated with latency simulation)
+    double local_cash_balance_;
+    std::unordered_map<int, double> local_position_;
+    std::unordered_map<int, OrderBook> local_orderbooks_;
+    std::unordered_map<int, Order> local_active_orders_;
 
-    double cash_balance;
+    // trading statistics
     std::unordered_map<int, int> num_trades_;
     std::unordered_map<int, double> trading_volume_;
     std::unordered_map<int, double> trading_value_;
     std::unordered_map<int, double> realized_pnl_;
-
-    std::unordered_map<int, double> local_position_;
 
     struct DelayedAction {
         ActionType type_;


### PR DESCRIPTION
`Recorder` now prints formatted Sharpe, Sortino, and maximum drawdown. 
`BacktestEngine` prints formatted total trade value, total trade volume, and total number of trades. 