### PR TITLE
bid and ask depth cached for each asset

### DIFF
--- a/config/grid_trading_config.txt
+++ b/config/grid_trading_config.txt
@@ -1,7 +1,7 @@
 tick_size=0.01
 lot_size=0.1
-grid_num=10
-grid_interval=5
-half_spread=2
+grid_num=5
+grid_interval=10
+half_spread=20
 position_limit=1000.0
 notional_order_qty=100.0

--- a/hftengine/backtest_main.cpp
+++ b/hftengine/backtest_main.cpp
@@ -28,17 +28,18 @@ int main() {
     std::unordered_map<int, AssetConfig> asset_configs;
     const int asset_id = 1;
     asset_configs.insert({asset_id, asset_config});
-    // auto logger = std::make_shared<Logger>("backtest.log", LogLevel::Error);
+    // auto logger = std::make_shared<Logger>("backtest.log", LogLevel::Warning);
     auto logger = nullptr;
 
-    BacktestEngine hbt(asset_configs, logger, 600);
-    Recorder recorder(1'000'000, logger);
+    double initial_cash = 1'000.0;
+    BacktestEngine hbt(asset_configs, logger, initial_cash);
+    Recorder recorder(100'000, logger);
     GridTrading grid_trading(1, grid_trading_config, logger);
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    std::uint64_t iter = 864000;
-    while (hbt.elapse(100'000) && iter-- > 0) {
+    std::uint64_t iter = 259200;
+    while (hbt.elapse(1'000'000) && iter-- > 0) {
         hbt.clear_inactive_orders();
         grid_trading.on_elapse(hbt);
         recorder.record(hbt, asset_id);

--- a/hftengine/core/orderbook/orderbook.cpp
+++ b/hftengine/core/orderbook/orderbook.cpp
@@ -33,6 +33,28 @@ OrderBook::OrderBook(double tick_size, double lot_size,
 }
 
 /**
+ * @brief Returns the bid book as a map of price levels to quantities.
+ *
+ * The bid book is sorted in descending order of price.
+ *
+ * @return A map of price levels (Ticks) to quantities (Quantity) for asks.
+ */
+std::map<Ticks, Quantity, std::greater<>> OrderBook::bid_book() const {
+    return bid_book_;
+}
+
+/**
+ * @brief Returns the ask book as a map of price levels to quantities.
+ *
+ * The ask book is sorted in ascending order of price.
+ *
+ * @return A map of price levels (Ticks) to quantities (Quantity) for asks.
+ */
+std::map<Ticks, Quantity> OrderBook::ask_book() const {
+    return ask_book_; 
+}
+
+/**
  * @brief Clears the order book by removing all bids and asks.
  *
  */

--- a/hftengine/core/orderbook/orderbook.h
+++ b/hftengine/core/orderbook/orderbook.h
@@ -46,6 +46,9 @@ class OrderBook {
     int bid_levels() const;
     int ask_levels() const;
 
+    std::map<Ticks, Quantity, std::greater<>> bid_book() const;
+    std::map<Ticks, Quantity> ask_book() const;
+
     // Clear book (e.g., on snapshot)
     void clear();
 

--- a/hftengine/core/recorder/recorder.cpp
+++ b/hftengine/core/recorder/recorder.cpp
@@ -260,7 +260,7 @@ void Recorder::print_performance_metrics() const {
     } catch (const std::exception &e) {
         std::cout << "Max Drawdown   : Error (" << e.what() << ")\n";
     }
-    std::cout << "==========================\n";
+    std::cout << "===========================\n";
 }
 
 /**

--- a/hftengine/core/trading/backtest_engine.cpp
+++ b/hftengine/core/trading/backtest_engine.cpp
@@ -572,31 +572,12 @@ const Depth BacktestEngine::depth(int asset_id) const {
                          std::to_string(asset_id),
                      LogLevel::Debug);
     }
-    // local_orderbooks_.at(asset_id).print_top_levels();
-    std::unordered_map<Ticks, Quantity> bid_depth;
-    /* int bid_levels = local_orderbooks_.at(asset_id).bid_levels();
-    for (int level = 0; level < bid_levels; level++) {
-        Ticks bid_level_price_ticks =
-            local_orderbooks_.at(asset_id).price_at_level(BookSide::Bid, level);
-        double bid_level_depth =
-            local_orderbooks_.at(asset_id).depth_at_level(BookSide::Bid, level);
-        bid_depth[bid_level_price_ticks] = bid_level_depth;
-    }*/
-    std::unordered_map<Ticks, Quantity> ask_depth;
-    /* int ask_levels = local_orderbooks_.at(asset_id).ask_levels();
-    for (int level = 0; level < ask_levels; level++) {
-        Ticks ask_level_price_ticks =
-            local_orderbooks_.at(asset_id).price_at_level(BookSide::Ask, level);
-        double ask_level_depth =
-            local_orderbooks_.at(asset_id).depth_at_level(BookSide::Ask, level);
-        ask_depth[ask_level_price_ticks] = ask_level_depth;
-    }*/
     return Depth{.best_bid_ = best_bid,
                  .bid_qty_ = bid_0_size,
                  .best_ask_ = best_ask,
                  .ask_qty_ = ask_0_size,
-                 .bid_depth_ = bid_depth,
-                 .ask_depth_ = ask_depth,
+                 .bid_depth_ = local_orderbooks_.at(asset_id).bid_book(),
+                 .ask_depth_ = local_orderbooks_.at(asset_id).ask_book(),
                  .tick_size_ = tick_sizes_.at(asset_id),
                  .lot_size_ = lot_sizes_.at(asset_id)};
 }
@@ -632,13 +613,8 @@ void BacktestEngine::print_trading_stats(int asset_id) const {
               << (trading_value_it != trading_value_.end()
                       ? trading_value_it->second
                       : 0.0)
-              << "\n";
-    std::cout << "Realized PnL       : "
-              << (realized_pnl_it != realized_pnl_.end()
-                      ? realized_pnl_it->second
-                      : 0.0)
-              << "\n";
-    std::cout << "=============================================\n";
+              << " USDT\n";
+    std::cout << "==========================================\n";
 }
 
 /**

--- a/hftengine/core/trading/depth.h
+++ b/hftengine/core/trading/depth.h
@@ -1,6 +1,6 @@
 /*
  * File: hftengine/core/trading/depth.h
- * Description: Level two data for an asset.
+ * Description: Level two price data, tick size, and lot size for an asset.
  * Author: Arvind Rathnashyam
  * Date: 2025-07-01
  * License: Proprietary
@@ -10,18 +10,18 @@
 
 #include <unordered_map>
 
-#include "../types/usings.h" 
+#include "../types/usings.h"
 
 /**
  * @brief Represents the best bid and ask prices and their quantities.
  */
 struct Depth {
-    Ticks best_bid_ = 0.0;
+    Ticks best_bid_ = 0;
     Quantity bid_qty_ = 0.0;
-    Ticks best_ask_ = 0.0;
+    Ticks best_ask_ = 0;
     Quantity ask_qty_ = 0.0;
-    std::unordered_map<Ticks, Quantity> bid_depth_;
-    std::unordered_map<Ticks, Quantity> ask_depth_;
+    std::map<Ticks, Quantity, std::greater<>> bid_depth_;
+    std::map<Ticks, Quantity> ask_depth_;
     double tick_size_;
     double lot_size_;
 };


### PR DESCRIPTION
Refactored `depth(int)` to now return the` ask_depth` as a `std::map<Ticks, Quantity>` and `bid_depth` as a `std::map<Ticks, Quantity, std::greater<>>`. So can now call on the state of the `local_orderbooks_`.