### PR TITLE
run backtest executable in github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,8 @@ jobs:
       run: |
         cd build
         ctest --output-on-failure
+        
+    - name: Run backtest executable
+      run: |
+        cd build
+        ./hftbacktest


### PR DESCRIPTION
The backtest executable must run without errors in the github workflow.