### PR TITLE
initial docs

### DIFF
--- a/docs/api/backtest_engine.md
+++ b/docs/api/backtest_engine.md
@@ -1,0 +1,85 @@
+# BacktestEngine API Reference
+
+The `BacktestEngine` class is the core simulation engine in **CryptoQuantLab**. It manages market data, order submission, execution, latency modeling, and portfolio state for one or more assets.
+
+---
+
+## Overview
+
+`BacktestEngine` simulates a trading environment using historical market data and user-defined strategies. It supports realistic latency for order entry, response, and market data feeds, and provides access to portfolio statistics and order book state.
+
+---
+
+## Constructor
+```cpp
+BacktestEngine(const std::unordered_map<int, core::trading::AssetConfig>&asset_configs,
+        const core::backtest::BacktestEngineConfig &engine_config,
+        std::shared_ptr<utils::logger::Logger> logger = nullptr);
+```
+
+- **asset_configs**: Map of asset IDs to their configuration.
+- **engine_config**: Simulation parameters (cash, latency, etc.).
+- **logger**: Optional logger for debug and info output.
+
+---
+
+## Core Methods
+
+### Simulation Control
+```cpp
+bool elapse(std::uint64_t us);
+```
+Advances the simulation clock by the specified microseconds, processing market events and delayed actions.
+
+---
+
+### Order Management
+```cpp
+OrderId submit_buy_order(int asset_id, Price price, Quantity quantity, TimeInForce tif, OrderType orderType);
+OrderId submit_sell_order(int asset_id, Price price, Quantity quantity, TimeInForce tif, OrderType orderType);
+void cancel_order(int asset_id, OrderId orderId);
+void clear_inactive_orders();
+```
+- **submit_buy_order / submit_sell_order**: Submit new buy/sell orders with simulated latency.
+- **cancel_order**: Cancel an active order.
+- **clear_inactive_orders**: Remove filled, cancelled, or expired orders from the local state.
+
+---
+
+### Portfolio and State Access
+- **orders**: Get all active orders for an asset.
+- **cash**: Current cash balance.
+- **equity**: Total portfolio value (cash + marked-to-market positions).
+- **position**: Net position for an asset.
+- **depth**: Current order book depth for an asset.
+- **current_time**: Current simulation timestamp (microseconds).
+
+---
+
+### Latency Configuration
+Set or get simulated latency for order entry, order response, and market data feed.
+
+---
+
+### Statistics and Reporting
+```cpp
+void print_trading_stats(int asset_id) const;
+```
+Prints trading statistics (number of trades, volume, value) for the specified asset.
+
+---
+## Notes
+
+- All order submissions and cancellations are subject to configured latency.
+- The engine supports multiple assets, each with independent order books and statistics.
+- Use the logger for detailed event tracing and debugging.
+
+---
+
+## See Also
+
+- [Configuration Guide](../configuration.md)
+- [Strategies Guide](../strategies.md)
+- [Usage Guide](../usage.md)
+
+---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,66 @@
+# Configuration Guide
+
+This document explains the configuration files used by **CryptoQuantLab**. Each config file is located in the `config/` directory and controls different aspects of the backtest engine, strategies, and output.
+
+---
+
+## 1. Asset Configuration (`asset_config.txt`)
+
+Defines the properties of the trading asset and data sources.
+
+**Parameters:**
+- `book_update_file`: Path to the Level 2 order book CSV file.
+- `trade_file`: Path to the trade data CSV file.
+- `tick_size`: Minimum price increment for the asset.
+- `lot_size`: Minimum tradeable quantity.
+- `contract_multiplier`: Multiplier for contract value (usually 1.0 for spot).
+- `is_inverse`: Set to `1` for inverse contracts, `0` otherwise.
+- `maker_fee`: Fee rate for maker orders.
+- `taker_fee`: Fee rate for taker orders.
+- `name`: Asset name (optional, for reference).
+
+---
+
+## 2. Backtest Engine Configuration (`backtest_engine_config.txt`)
+
+Sets simulation parameters for the backtest engine.
+
+**Parameters:**
+- `initial_cash`: Starting cash balance for the simulation.
+- `order_entry_latency_us`: Latency (in microseconds) for order entry.
+- `order_response_latency_us`: Latency (in microseconds) for order updates.
+- `market_feed_latency_us`: Latency (in microseconds) for market data feed.
+
+## 3. Recorder Configuration (`recorder_config.txt`)
+
+Controls how performance metrics are recorded and output. 
+
+**Parameters:**
+- `interval_us`: Time interval (in microseconds) between equity snapshots.
+- `output_file`: Output CSV file for recorded data.
+
+---
+
+## 4. Backtest Run Configuration (`backtest_config.txt`)
+
+Controls the main backtest loop.
+
+**Parameters:**
+- `elapse_us`: Time to advance the simulation clock per iteration (in microseconds).
+- `iterations`: Number of simulation iterations to run.
+
+---
+
+## Notes
+
+- All config files use `key=value` format. Lines starting with `#` are comments.
+- Paths should be relative to the project root or absolute.
+- If a parameter is missing, a default value may be used (see source code for defaults).
+
+---
+
+## See Also
+
+- [Getting Started](getting_started.md)
+- [Usage Guide](usage.md)
+- [Strategies](strategies.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,58 @@
+# CryptoQuantLab Documentation
+
+Welcome to the documentation for **CryptoQuantLab** – a high-performance C++ framework for backtesting and simulating high-frequency trading strategies on Level 2 crypto market data.
+
+---
+
+## Overview
+
+CryptoQuantLab provides realistic order book simulation, queue position tracking, and latency modeling for research and development of market-making and latency-sensitive strategies. The framework is modular, extensible, and designed for both backtesting and future live simulation.
+
+---
+
+## Table of Contents
+
+- [Getting Started](getting_started.md)
+- [Configuration Guide](configuration.md)
+- [Usage Guide](usage.md)
+- [Reference](reference/backtest_engine.md)
+- [Strategies](strategies.md)
+- [Examples](examples.md)
+- [Live Simulation](live_simulation.md)
+- [Contributing](contributing.md)
+- [FAQ](faq.md)
+- [Changelog](changelog.md)
+
+---
+
+## Key Features
+
+- **C++20 implementation** for speed and low-level control
+- **Full depth-of-book simulation** from Level 2 feeds
+- **Feed and order latency modeling**
+- **Queue position estimation**
+- **Modular, testable architecture**
+- **Extensible strategy interface**
+- **Comprehensive unit tests**
+
+---
+
+## Quick Links
+
+- [Project Repository](https://github.com/your_username/cryptoquantlab)
+- [License](../LICENSE)
+
+---
+
+## Getting Help
+
+If you have questions, please check the [FAQ](faq.md) or open an issue on GitHub.
+
+---
+
+## About
+
+CryptoQuantLab is developed and maintained by Arvind Rathnashyam.  
+For inquiries, contact: arvindkrv@protonmail.com
+
+---

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,106 @@
+# Strategies Guide
+
+This guide describes how strategies work in **CryptoQuantLab**, how to use the built-in grid trading strategy, and how to implement your own.
+
+---
+
+## Strategy Architecture
+
+Strategies in CryptoQuantLab are implemented as C++ classes derived from the abstract `Strategy` base class:
+```c++
+class Strategy { 
+  public: 
+    virtual void initialize() = 0; 
+    virtual void on_elapse(corebacktestBacktestEngine &hbt) = 0; 
+    virtual ~Strategy() = default; 
+};
+
+```
+- **initialize()**: Called once before the backtest loop starts.
+- **on_elapse()**: Called on each simulation step, receives the backtest engine for order management and market data access.
+
+---
+
+## Built-in Strategy: Grid Trading
+
+The framework includes a basic grid trading strategy, suitable for market making and liquidity provision.
+
+### Overview
+
+- Places buy and sell limit orders at multiple price levels around the mid price.
+- Dynamically cancels and resubmits orders to maintain the grid.
+- Respects position limits and notional order size.
+
+### Configuration
+
+Grid trading parameters are set in `config/grid_trading_config.txt`:
+**Parameters:**
+- `grid_num`: Number of grid levels on each side (bid/ask)
+- `grid_interval`: Tick interval between grid levels
+- `half_spread`: Half the spread in ticks for grid centering
+- `position_limit`: Maximum allowed position size
+- `notional_order_qty`: Notional value per grid order
+
+### Usage
+
+The grid trading strategy is instantiated and run in the main backtest loop:
+
+```c++
+core::strategy::GridTrading grid_trading(asset_id, grid_trading_config, logger);
+while (engine.elapse(backtest_config.elapse_us) && iter-- > 0) { 
+    engine.clear_inactive_orders();
+    grid_trading.on_elapse(engine); 
+    recorder.record(engine, asset_id); 
+}
+```
+---
+
+## Implementing Custom Strategies
+
+To add your own strategy:
+
+1. **Create a new class** in `core/strategy/` that inherits from `Strategy`.
+2. **Implement** the `initialize()` and `on_elapse()` methods.
+3. **Use the BacktestEngine** in `on_elapse()` to access market data and submit/cancel orders.
+
+**Example Skeleton:**
+```c++
+#include "core/strategy/strategy.h"
+
+void on_elapse(core::backtest::BacktestEngine &engine) override {
+    // Access market data
+    auto mid_price = engine.get_mid_price(asset_id);
+    
+    // Submit orders, manage positions, etc.
+    if (/* some condition */) {
+        engine.submit_order(/* parameters */);
+    }
+}
+```
+4. **Instantiate your strategy** in the main backtest file and call its methods in the simulation loop.
+
+---
+
+## Strategy Testing
+
+- Add unit tests for your strategy in `tests/strategies/`.
+- Use the provided Catch2 framework for automated testing.
+
+---
+
+## Tips
+
+- Use the logger for debugging and tracking strategy actions.
+- Tune grid and risk parameters in the config files for optimal results.
+- Review the [examples.md](examples.md) for sample strategy implementations.
+
+---
+
+## Further Reading
+
+- [Configuration Guide](configuration.md)
+- [Usage Guide](usage.md)
+- [Examples](examples.md)
+- [FAQ](faq.md)
+
+---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,83 @@
+# Usage Guide
+
+This guide explains how to run backtests, interpret results, and use the main features of **CryptoQuantLab**.
+
+---
+
+## Running a Backtest
+
+After building the project, run the main executable from the build directory:
+
+```bash
+./hftbacktest
+```
+
+This will:
+- Load configuration files from the `config/` directory
+- Run the backtest engine for the specified number of iterations
+- Print final equity, performance metrics, and trading statistics
+- Generate a plot of equity and position (requires Python)
+
+---
+
+## Command-Line Options
+
+Currently, the main executable does **not** accept command-line arguments.  
+All settings are controlled via configuration files in the `config/` directory.
+
+---
+
+## Output
+
+After a successful run, you will see:
+- **Backtest wall time** (total runtime in seconds)
+- **Final equity** (portfolio value at the end of the simulation)
+- **Performance metrics**:
+  - Sharpe Ratio
+  - Sortino Ratio
+  - Max Drawdown
+- **Trading statistics** for each asset:
+  - Number of trades
+  - Trading volume
+  - Trading value
+
+If plotting is enabled, a CSV file and plot will be generated for each asset.
+
+---
+
+## Example Workflow
+
+1. Edit configuration files in `config/` as needed.
+2. Build the project.
+3. Run the backtest.
+
+---
+
+## Custom Strategies
+
+To implement or modify strategies:
+- Edit or add strategy classes in `core/strategy/`
+- Update configuration files as needed
+- Rebuild and rerun the backtest
+
+See [strategies.md](strategies.md) for more details.
+
+---
+
+## Troubleshooting
+
+- Ensure all required config files are present in `config/`
+- Check for missing or invalid data files referenced in configs
+- If plotting fails, verify Python and required packages are installed
+
+---
+
+## Further Reading
+
+- [Getting Started](getting_started.md)
+- [Configuration Guide](configuration.md)
+- [Strategies](strategies.md)
+- [Examples](examples.md)
+- [FAQ](faq.md)
+
+---


### PR DESCRIPTION
Create an initial set of docs. Details are include on the config files, custom strategy configuration, and the `BacktestEngine`. 