### PR TITLE
Fix compilation warnings

### DIFF
--- a/config/backtest_config.txt
+++ b/config/backtest_config.txt
@@ -1,2 +1,2 @@
 elapse_us=1000000
-iterations=432000
+iterations=86400

--- a/cryptoquantengine/core/execution_engine/execution_engine.cpp
+++ b/cryptoquantengine/core/execution_engine/execution_engine.cpp
@@ -333,7 +333,7 @@ bool ExecutionEngine::execute_fok_order(
     int levels = (side == TradeSide::Buy)
                      ? orderbooks_.at(asset_id).ask_levels()
                      : orderbooks_.at(asset_id).bid_levels();
-    Quantity available_qty;
+    Quantity available_qty = 0.0;
     while (++level < levels && available_qty < order->quantity_) {
         Ticks level_price_ticks =
             (side == TradeSide::Buy)

--- a/cryptoquantengine/core/orderbook/orderbook.cpp
+++ b/cryptoquantengine/core/orderbook/orderbook.cpp
@@ -22,8 +22,8 @@ namespace orderbook {
 
 OrderBook::OrderBook(double tick_size, double lot_size,
                      std::shared_ptr<utils::logger::Logger> logger)
-    : tick_size_(tick_size), lot_size_(lot_size), logger_(logger),
-      last_update_(UpdateType::Snapshot) {
+    : tick_size_(tick_size), lot_size_(lot_size), bid_book_(), ask_book_(),
+      last_update_(UpdateType::Snapshot), logger_(logger){
     if (tick_size <= 0.0) {
         throw std::invalid_argument("Tick size must be positive: " +
                                     std::to_string(tick_size));


### PR DESCRIPTION
Resolve compilation warnings in the codebase. 
- For `DelayedAction` structs, explicit initialization of `std::nullopt` for `std::optional` members. 
- Fixed member initialization order in the `OrderBook`. 