### PR TITLE
executable for benchmarking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,34 @@ target_compile_options(backtest PRIVATE
 
 target_link_libraries(backtest PRIVATE Threads::Threads)
 
+add_executable(benchmark
+  cryptoquantengine/benchmark.cc
+  cryptoquantengine/core/orderbook/orderbook.cpp
+  cryptoquantengine/utils/config/config_reader.cpp
+  cryptoquantengine/core/execution_engine/execution_engine.cpp
+  cryptoquantengine/core/backtest_engine/backtest_engine.cpp
+  cryptoquantengine/core/market_data/market_data_feed.cpp
+  cryptoquantengine/core/market_data/readers/base_stream_reader.cpp
+  cryptoquantengine/core/market_data/readers/book_stream_reader.cpp
+  cryptoquantengine/core/market_data/readers/trade_stream_reader.cpp
+  cryptoquantengine/core/recorder/recorder.cpp
+  cryptoquantengine/utils/logger/logger.cpp
+)
+
+target_include_directories(benchmark PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/cryptoquantengine
+  ${CMAKE_CURRENT_SOURCE_DIR}/external 
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/websocketpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/json
+)
+
+target_compile_options(benchmark PRIVATE
+  $<$<CONFIG:Release>:-O3>
+  $<$<CONFIG:Debug>:-O3 -Wall -Wextra -Wpedantic>
+)
+
+target_link_libraries(benchmark PRIVATE Threads::Threads)
+
 add_executable(stream
   cryptoquantengine/wss_main.cc
   cryptoquantengine/core/market_data/readers/ws/binance_stream_reader.cc

--- a/config/backtest_config.txt
+++ b/config/backtest_config.txt
@@ -1,2 +1,2 @@
 elapse_us=100000
-iterations=864000
+iterations=86400

--- a/cryptoquantengine/benchmark.cc
+++ b/cryptoquantengine/benchmark.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Arvind Rathnashyam - arvindkrv@protonmail.com
+ *
+ * Please see the LICENSE file for the terms and conditions
+ * associated with this software.
+ */
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include "core/backtest_engine/backtest_engine.h"
+#include "core/recorder/recorder.h"
+#include "utils/config/config_reader.h"
+#include "utils/logger/log_level.h"
+#include "utils/logger/logger.h"
+
+int main(int argc, char **argv) {
+    std::string asset_cfg = (argc > 1) ? argv[1] : "../config/asset_config.txt";
+    std::string grid_cfg =
+        (argc > 2) ? argv[2] : "../config/grid_trading_config.txt";
+    std::string bt_engine_cfg =
+        (argc > 3) ? argv[3] : "../config/backtest_engine_config.txt";
+    std::string recorder_cfg =
+        (argc > 4) ? argv[4] : "../config/recorder_config.txt";
+    std::string bt_cfg = (argc > 5) ? argv[5] : "../config/backtest_config.txt";
+
+    auto logger = nullptr;
+
+    // read configs
+    utils::config::ConfigReader config_reader;
+    const auto asset_config = config_reader.get_asset_config(asset_cfg);
+    const auto backtest_engine_config =
+        config_reader.get_backtest_engine_config(bt_engine_cfg);
+    const auto recorder_config =
+        config_reader.get_recorder_config(recorder_cfg);
+    const auto backtest_config = config_reader.get_backtest_config(bt_cfg);
+    
+    const int asset_id{1};
+    const std::unordered_map<int, core::trading::AssetConfig> asset_configs = {{asset_id, asset_config}};
+    
+    core::backtest::BacktestEngine engine(asset_configs, backtest_engine_config,
+                                          logger);
+    core::recorder::Recorder recorder(recorder_config.interval_us, logger);
+    // backtest loop
+    const auto start = std::chrono::high_resolution_clock::now();
+    std::uint64_t iter = backtest_config.iterations;
+    while (engine.elapse(backtest_config.elapse_us) && iter-- > 0) {
+        engine.clear_inactive_orders();
+        recorder.record(engine, asset_id);
+    }
+    const auto end = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double> elapsed = end - start;
+
+    std::cout << "Benchmark wall time: " << elapsed.count() << " seconds\n";
+
+    return 0;
+}


### PR DESCRIPTION
Benchmark without a strategy, used only for processing market events (trades, book updates). In the current commit, benchmark averages ~30 seconds.